### PR TITLE
Several changes version v0.1.1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.tfplan
 *.pem
 *.zip
+
+.idea

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See https://github.com/gruntwork-io/pre-commit
+# Will need to install some pre-requisites
+#       pre-commit      https://pre-commit.com/#install
+#       tflint          https://github.com/terraform-linters/tflint/
+# Can then install with
+#       pre-commit install
+# Can do a manual run with
+#       pre-commit run
+
+repos:
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.9                                                 # Get the latest from: https://github.com/gruntwork-io/pre-commit/releases
+    hooks:
+      - id: terraform-fmt
+      - id: tflint 
+        args: ["--deep", "--module"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
-<a name="unreleased"></a>
 ## [Unreleased]
+- Added: ALB logging - both ALBs log to the same bucket, using distinct prefixes - api and push
 - Updated: Upgraded AWS provider from = 2.68.0 to ~> 2.70.0
 - Updated: Switched to using templatefile function rather than deprecated template provider
 
 
-<a name="v0.1.1"></a>
 ## [v0.1.1] 2020-08-13
 - Added: Added ability to set ECS image url and image tag overrides, this is based on @segfault's PR at https://github.com/covidgreen/covid-green-infra/pull/4
 - Updated: Switched lambdas from using the AWSLambdaBasicExecutionRole to AWSLambdaVPCAccessExecutionRole managed policy
@@ -30,6 +29,6 @@ All notable changes to this project will be documented in this file.
 - Fixed: Linting issues - no logic
 - Added: Split RDS user usage so we no longer need to use the master credentials
 
-<a name="v0.1.0"></a>
+
 ## [v0.1.0] 2020-08-13
 - Initial content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 <a name="unreleased"></a>
 ## [Unreleased]
+- Updated: Upgraded AWS provider from = 2.68.0 to ~> 2.70.0
+- Updated: Switched to using templatefile function rather than deprecated template provider
+
 
 <a name="v0.1.1"></a>
 ## [v0.1.1] 2020-08-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Change Log
+
+All notable changes to this project will be documented in this file.
+
+<a name="unreleased"></a>
+## [Unreleased]
+
+<a name="v0.1.1"></a>
+## [v0.1.0] 2020-08-13
+- Added: Added ability to set ECS image url and image tag overrides, this is based on @segfault's PR at https://github.com/covidgreen/covid-green-infra/pull/4
+- Updated: Switched lambdas from using the AWSLambdaBasicExecutionRole to AWSLambdaVPCAccessExecutionRole managed policy
+- Updated: Renamed the "root_profile" var and "root" AWS provider to "dns" as this is confusing, removed a redundant aws provider "root_us"
+- Updated: Added changes @segfault added re explicit usage of the AWS CLI `--output json` usage in some of the scripts
+- Removed: Removed Terraform validate from the pre-commit hook config as this is being used as a module, have left the s3 backend config for now
+- Updated: Switched all the lambdas from nodejs10.x to nodejs12.x
+- Added: Use variables for the lambda memory size and timeout attributes with defaults, so we can configure via env-vars files
+- Removed: Extracted cti, gct and ni content into specific repos - Will not be managed by this repo
+- Added: Added new AWS parameters certificate_audience and jwt_issuer and removed security_exposure_limit AWS parameter
+- Added: Docs on the 2 approaches to managing a project - external to this repo and internal to this repo
+- Added: Added RDS reader/writer endpoint outputs
+- Added: Surfaced bastion ASG desired count as a variable, will need when we use this repo as a module
+- Added: Switched to using path.module prefixes for the CloudWatch dashboard template and the ECS container defintion templates
+- Fixed: Changed the create TF store backend script to cater for us-east-1 being a special case - Location constraints
+- Fixed: Replace all refs to cti, gct and ni with xyz in docs and shell script comments - this is just prep for the open source branch
+- Added: Added the following optional lambdas to the operators group execute list: daily-registrations-reporter, download and upload
+- Added: Pre-commit hook to include TF fmt, validation and linting
+- Fixed: Linting issues - no logic
+- Added: Split RDS user usage so we no longer need to use the master credentials
+
+<a name="v0.1.0"></a>
+## [v0.1.0] 2020-08-13
+- Initial content

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 <a name="v0.1.1"></a>
-## [v0.1.0] 2020-08-13
+## [v0.1.1] 2020-08-13
 - Added: Added ability to set ECS image url and image tag overrides, this is based on @segfault's PR at https://github.com/covidgreen/covid-green-infra/pull/4
 - Updated: Switched lambdas from using the AWSLambdaBasicExecutionRole to AWSLambdaVPCAccessExecutionRole managed policy
 - Updated: Renamed the "root_profile" var and "root" AWS provider to "dns" as this is confusing, removed a redundant aws provider "root_us"

--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@
 # 	make xyz-dev-init
 # 	make xyz-dev-plan
 # 	make xyz-dev-apply
-# We assume you have an AWS profile with the the PROJECT-ENVIRONMENT so in above case xyz-dev
-# 	This is the same profile that should exist in the env-vars file
+# We assume you have an AWS profile named PROJECT-ENVIRONMENT i.e. xyz-dev
+# 	This is the same profile that should exist in the env-vars files
 
 .ONESHELL:
 .SHELL := /bin/bash
@@ -48,6 +48,7 @@ AWS_PROFILE = $(PROJECT_ENVIRONMENT_KEY)
 # Determine from tf vars file(s) - will use the first match
 AWS_REGION = $(shell grep '^aws_region' $(PROJECT_ENVIRONMENT_TFVAR_FILE) $(PROJECT_TFVAR_FILE) | head -n 1 | cut -d '"' -f 2)
 
+# NOTE: Uses a convention
 TERRAFORM_BACKEND_BUCKET ?= $(PROJECT_ENVIRONMENT_KEY)-terraform-store
 TERRAFORM_BACKEND_KEY ?= $(PROJECT_KEY)
 TERRAFORM_BACKEND_TABLE ?= $(PROJECT_ENVIRONMENT_KEY)-terraform-lock
@@ -64,24 +65,6 @@ xyz-dev-plan:
 	@$(MAKE_TF_PLAN) ENVIRONMENT=dev PROJECT_KEY=xyz
 xyz-dev-apply:
 	@$(MAKE_TF_APPLY) ENVIRONMENT=dev PROJECT_KEY=xyz
-
-# QA
-.PHONY: xyz-qa-init xyz-qa-plan xyz-qa-apply
-xyz-qa-init:
-	@$(MAKE_TF_INIT) ENVIRONMENT=qa PROJECT_KEY=xyz
-xyz-qa-plan:
-	@$(MAKE_TF_PLAN) ENVIRONMENT=qa PROJECT_KEY=xyz
-xyz-qa-apply:
-	@$(MAKE_TF_APPLY) ENVIRONMENT=qa PROJECT_KEY=xyz
-
-# PROD
-.PHONY: xyz-prod-init xyz-prod-plan xyz-prod-apply
-xyz-prod-init:
-	@$(MAKE_TF_INIT) ENVIRONMENT=prod PROJECT_KEY=xyz
-xyz-prod-plan:
-	@$(MAKE_TF_PLAN) ENVIRONMENT=prod PROJECT_KEY=xyz
-xyz-prod-apply:
-	@$(MAKE_TF_APPLY) ENVIRONMENT=prod PROJECT_KEY=xyz
 
 
 # #########################################

--- a/alb.tf
+++ b/alb.tf
@@ -29,8 +29,13 @@ resource "aws_lb" "api" {
   enable_http2                     = true
   ip_address_type                  = "dualstack"
   enable_deletion_protection       = true
+  tags                             = module.labels.tags
 
-  tags = module.labels.tags
+  access_logs {
+    bucket  = module.alb_logs.aws_logs_bucket
+    prefix  = "api"
+    enabled = true
+  }
 }
 
 resource "aws_lb_target_group" "api" {
@@ -120,8 +125,13 @@ resource "aws_lb" "push" {
   enable_http2                     = true
   ip_address_type                  = "dualstack"
   enable_deletion_protection       = true
+  tags                             = module.labels.tags
 
-  tags = module.labels.tags
+  access_logs {
+    bucket  = module.alb_logs.aws_logs_bucket
+    prefix  = "push"
+    enabled = true
+  }
 }
 
 resource "aws_lb_target_group" "push" {
@@ -159,4 +169,21 @@ resource "aws_lb_listener" "push_https" {
     target_group_arn = aws_lb_target_group.push.id
     type             = "forward"
   }
+}
+
+# #########################################
+# ALB logs - single bucket for both ALBs each with their own prefix
+# #########################################
+module "alb_logs" {
+  source  = "trussworks/logs/aws"
+  version = "8.1.0"
+
+  alb_logs_prefixes       = ["api", "push"]
+  allow_alb               = true
+  default_allow           = false
+  force_destroy           = true
+  region                  = var.aws_region
+  s3_bucket_name          = format("%s-alb-logs", module.labels.id)
+  s3_log_bucket_retention = var.logs_retention_days
+  tags                    = module.labels.tags
 }

--- a/bastion.tf
+++ b/bastion.tf
@@ -14,7 +14,7 @@ data "aws_ami" "amazon_linux_2" {
 
 resource "aws_autoscaling_group" "bastion" {
   count               = local.bastion_enabled_count
-  desired_capacity    = 1
+  desired_capacity    = var.bastion_asg_desired_count
   max_size            = 1
   min_size            = 0
   name                = format("%s-bastion", module.labels.id)

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -1,25 +1,21 @@
-data "template_file" "dashboard" {
-  template = file(format("%s/templates/dashboard.json", path.module))
-
-  vars = {
-    account_id            = data.aws_caller_identity.current.account_id
-    region                = var.aws_region
-    environment           = var.environment
-    gateway_name          = "${module.labels.id}-gw"
-    ecs_cluster_name      = module.labels.id
-    ecs_push_service_name = aws_ecs_service.push.name
-    ecs_api_service_name  = aws_ecs_service.api.name
-    rds_db_cluster_name   = module.rds_cluster_aurora_postgres.cluster_identifier
-    lambda_token_fn_name  = "${module.labels.id}-token"
-    lambda_cso_fn_name    = "${module.labels.id}-cso"
-    lambda_stats_fn_name  = "${module.labels.id}-stats"
-    api_lb_arn_suffix     = aws_lb.api.arn_suffix
-    push_lb_arn_suffix    = aws_lb.push.arn_suffix
-    api_log_group         = "${module.labels.id}-api"
-  }
-}
-
 resource "aws_cloudwatch_dashboard" "monitoring_alarms_dashboard" {
   dashboard_name = module.labels.id
-  dashboard_body = data.template_file.dashboard.rendered
+
+  dashboard_body = templatefile(format("%s/templates/dashboard.json", path.module),
+    {
+      account_id            = data.aws_caller_identity.current.account_id
+      region                = var.aws_region
+      environment           = var.environment
+      gateway_name          = "${module.labels.id}-gw"
+      ecs_cluster_name      = module.labels.id
+      ecs_push_service_name = aws_ecs_service.push.name
+      ecs_api_service_name  = aws_ecs_service.api.name
+      rds_db_cluster_name   = module.rds_cluster_aurora_postgres.cluster_identifier
+      lambda_token_fn_name  = "${module.labels.id}-token"
+      lambda_cso_fn_name    = "${module.labels.id}-cso"
+      lambda_stats_fn_name  = "${module.labels.id}-stats"
+      api_lb_arn_suffix     = aws_lb.api.arn_suffix
+      push_lb_arn_suffix    = aws_lb.push.arn_suffix
+      api_log_group         = "${module.labels.id}-api"
+  })
 }

--- a/dashboard.tf
+++ b/dashboard.tf
@@ -1,5 +1,5 @@
 data "template_file" "dashboard" {
-  template = file("templates/dashboard.json")
+  template = file(format("%s/templates/dashboard.json", path.module))
 
   vars = {
     account_id            = data.aws_caller_identity.current.account_id

--- a/dns.tf
+++ b/dns.tf
@@ -3,7 +3,7 @@
 # #########################################
 data "aws_route53_zone" "primary" {
   count        = local.enable_dns_count
-  provider     = aws.root
+  provider     = aws.dns
   name         = var.route53_zone
   private_zone = false
 }
@@ -24,7 +24,7 @@ resource "aws_acm_certificate" "wildcard_cert" {
 
 resource "aws_route53_record" "wildcard_cert_validation" {
   count           = local.enable_certificates_count
-  provider        = aws.root
+  provider        = aws.dns
   name            = aws_acm_certificate.wildcard_cert[0].domain_validation_options.0.resource_record_name
   type            = aws_acm_certificate.wildcard_cert[0].domain_validation_options.0.resource_record_type
   zone_id         = data.aws_route53_zone.primary[0].id
@@ -49,7 +49,7 @@ resource "aws_acm_certificate_validation" "wildcard_cert" {
 
 resource "aws_acm_certificate" "wildcard_cert_us" {
   count             = local.enable_certificates_count
-  provider          = aws.us
+  provider          = aws.us_east_1
   domain_name       = var.wildcard_domain
   validation_method = "DNS"
 
@@ -60,7 +60,7 @@ resource "aws_acm_certificate" "wildcard_cert_us" {
 
 resource "aws_route53_record" "wildcard_cert_validation_us" {
   count           = local.enable_certificates_count
-  provider        = aws.root
+  provider        = aws.dns
   name            = aws_acm_certificate.wildcard_cert_us[0].domain_validation_options.0.resource_record_name
   type            = aws_acm_certificate.wildcard_cert_us[0].domain_validation_options.0.resource_record_type
   zone_id         = data.aws_route53_zone.primary[0].id
@@ -75,7 +75,7 @@ resource "aws_route53_record" "wildcard_cert_validation_us" {
 
 resource "aws_acm_certificate_validation" "wildcard_cert_us" {
   count                   = local.enable_certificates_count
-  provider                = aws.us
+  provider                = aws.us_east_1
   certificate_arn         = aws_acm_certificate.wildcard_cert_us[0].arn
   validation_record_fqdns = [aws_route53_record.wildcard_cert_validation_us[0].fqdn]
 
@@ -89,7 +89,7 @@ resource "aws_acm_certificate_validation" "wildcard_cert_us" {
 # #########################################
 resource "aws_route53_record" "api" {
   count    = local.enable_dns_count
-  provider = aws.root
+  provider = aws.dns
   zone_id  = data.aws_route53_zone.primary[0].id
   name     = var.api_dns
   type     = "A"
@@ -110,7 +110,7 @@ resource "aws_route53_record" "api" {
 
 resource "aws_route53_record" "push" {
   count    = local.enable_dns_count
-  provider = aws.root
+  provider = aws.dns
   zone_id  = data.aws_route53_zone.primary[0].id
   name     = var.push_dns
   type     = "A"

--- a/docs/bastion.md
+++ b/docs/bastion.md
@@ -10,7 +10,7 @@ There is a schedule to scale down the bastions at 21:01 UTC each day - so your s
 - You should then be able to see the instance on the AWS console and can select and hit Connect -> Session Manager
 
 
-# Postgres client installation
+# PostgreSQL client installation
 The postgresql11 package will be installed using cloud-init, but if you need to install can use
 ```sudo amazon-linux-extras install postgresql11```
 
@@ -19,5 +19,5 @@ The postgresql11 package will be installed using cloud-init, but if you need to 
 - Anyone wishing to use the bastion will need to have an AWS account
 - Will need to connect via the AWS console
 - If we do an apply if a bastion instance is running it will be terminated as we will reset the desired count to 0
-	- Can temp edit the bastion.tf file and set the desired_count to 1 to avoid this
+	- Can temp edit the bastion_asg_desired_count in the variables.tf file and set the desired_count to 1 to avoid this
 - Since we use a data source to get the latest AWS Linux 2 AMI this may sometimes appear as change in the plan

--- a/docs/creating-a-new-project.md
+++ b/docs/creating-a-new-project.md
@@ -1,5 +1,5 @@
 # Checklist
-Using a project with key **xyz** and a **dev** environment.
+Using a project with key **xyz** and a **dev** environment
 
 
 ## Create an AWS profile
@@ -7,7 +7,7 @@ Add a xyz-dev profile to ~/.aws/credentials
 
 
 ## Create the infra CI user - admin privs by default
-See [../scripts/create-infra-ci-user.sh] script
+See [script](../scripts/create-infra-ci-user.sh)
 
 ```
 # Set your AWS_PROFILE
@@ -21,7 +21,7 @@ export AWS_PROFILE=xyz-dev
 
 
 ## Create the Terraform state backend
-See [../scripts/create-tf-state-backend.sh] script
+See [script](../scripts/create-tf-state-backend.sh)
 
 ```
 # Set your AWS_PROFILE
@@ -30,6 +30,7 @@ export AWS_PROFILE=xyz-dev
 # Create
 ./scripts/create-tf-state-backend.sh eu-west-1 xyz-dev-terraform-store xyz-dev-terraform-lock
 ```
+
 
 ## Import TLS certificates
 In some cases we need to use certificates that are supplied
@@ -46,13 +47,53 @@ In some cases where we manage the DNS we may need to help with additional DNS re
 ## Create the AWS SecretsManager secrets
 We need to create the secrets outside of Terraform, see the [secrets/parameters](./secrets-parameters.md) doc.
 
+Like so - may have to watch for funny chars needing escaping - ignored here
+```
+generate-random() {
+	length=${1:-32}
 
-## Create the env-vars files
+	LC_ALL=C tr -dc 'A-Za-z0-9'\''()*+,-./:;<=>?@[\]^_{|}~' </dev/urandom | head -c ${length} ; echo
+}
+
+generate-random-alphanumeric() {
+	length=${1:-32}
+
+	LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c ${length} ; echo
+}
+
+./scripts/aws-secrets.sh create dev-xyz-device-check '{ "keyId": "FILL-ME-IN", "teamId": "FILL-ME-IN", "key": "-----BEGIN PRIVATE KEY-----\nFILL-ME-IN\n-----END PRIVATE KEY-----", "apkPackageName": "",  "apkDigestSha256": "",  "apkCertificateDigestSha256": "",  "safetyNetRootCa": "-----BEGIN CERTIFICATE-----\nFILL-ME-IN\n-----END CERTIFICATE-----", "timeDifferenceThresholdMins": 10 }'
+./scripts/aws-secrets.sh create dev-xyz-encrypt '{ "key": "'$(generate-random 32)'" }'
+./scripts/aws-secrets.sh create dev-xyz-exposures '{ "privateKey": "-----BEGIN EC PRIVATE KEY-----\nFILL-ME-IN\n-----END EC PRIVATE KEY-----", "signatureAlgorithm": "1.2.840.10045.4.3.2", "verificationKeyId": "", "verificationKeyVersion": "v1" }'
+./scripts/aws-secrets.sh create dev-xyz-header-x-secret '{ "header-secret":"'$(generate-random-alphanumeric 96)'" }'
+./scripts/aws-secrets.sh create dev-xyz-jwt '{ "key": "'$(generate-random 32)'" }'
+./scripts/aws-secrets.sh create dev-xyz-rds '{ "username":"rds_admin_user","password":""'$(generate-random 32)'" }'
+./scripts/aws-secrets.sh create dev-xyz-rds-read-only '{ "username":"read_only_user","password":"'$(generate-random 32)'" }'
+./scripts/aws-secrets.sh create dev-xyz-rds-read-write '{ "username":"read_write_user","password":"'$(generate-random 32)'" }'
+./scripts/aws-secrets.sh create dev-xyz-rds-read-write-create '{ "username": "read_write_create_user", "password": "'$(generate-random 32)'" }'
+
+# Do the same for optionals
+```
+**Note:** the rds secret is particularly important as changing it will require an RDS replacement as far as I can tell
+
+
+## Create project content
+There are 2 approaches to doing this
+
+### a) Use a dedicated git repo
+This is the preferred approach, in this case we treat this repo as a Terraform module
+
+#### Git repo
+Create a git repo which uses this repos content as a a module
+- Will need a module which points at this repo as the module source
+- Will need a variables.tf copy
+- will need an ouputs.tf copy
+
+#### env-vars files
 
 | File                    | Content                                                    |
 | ------------------------| -----------------------------------------------------------|
-| env-vars/cti.tfvars     | Contains the CTI values that are the same across all envs  |
-| env-vars/xyz-dev.tfvars | Contains the CTI values that are specific to the dev env   |
+| env-vars/common.tfvars  | Contains values that are the same across all envs          |
+| env-vars/dev.tfvars     | Contains values that are specific to the dev env           |
 
 With these we need to decide on some optionals
 - Enable DNS where we manage the DNS, in some cases we do not manage the DNS
@@ -60,14 +101,30 @@ With these we need to decide on some optionals
 - Some lambdas are optional
 - Some secrets/parameters are optional
 
+#### Create the Makefile targets
+Will need to create the following targets
 
-## Slack channel/application
-May need to create a slack application/channel - usually for the prod env only at this time.
-- Application will be PROJECT-bot i.e. xyz-bot
-- Channel name will be PROJECT-contact-tracing-alarms i.e ctii-contact-tracing-alarms
+| Target        | Description                                                                        |
+| --------------| -----------------------------------------------------------------------------------|
+| dev-init      | Does the Terraform module pulls and backend config                                 |
+| dev-plan      | Runs a Terraform plan, creating a local TF plan file i.e. terraform-dev.tfplan     |
+| dev-apply     | Does a Terraform apply using the created TF plan file                              |
 
+### b) Add content in this repo
+#### env-vars files
 
-## Create the Makefile targets
+| File                    | Content                                                    |
+| ------------------------| -----------------------------------------------------------|
+| env-vars/xyz.tfvars     | Contains the xyx values that are the same across all envs  |
+| env-vars/xyz-dev.tfvars | Contains the xyz values that are specific to the dev env   |
+
+With these we need to decide on some optionals
+- Enable DNS where we manage the DNS, in some cases we do not manage the DNS
+- Enable TLS certificates where we manage the certificates, in some cases we need to import certificates
+- Some lambdas are optional
+- Some secrets/parameters are optional
+
+#### Create the Makefile targets
 Will need to create the following targets.
 
 | Target        | Description                                                                        |
@@ -78,7 +135,9 @@ Will need to create the following targets.
 
 
 ## Post standup tasks
+- Enable PostgreSQL extensions and create DB users - see [here](./db.md)
 - Seed the DB setting(s) tables
-- Create DB users - see [here](./db.md)
 - Complete DNS config if needed - with external party
 - Complete SMS provider configuration - if using an external SMS provider
+- Over to the devs to manage the s/w deployments - needs to come after the DB configuration
+- Configure monitoring - alarms/alerting/slack notifications etc. - outside the scope of this repo

--- a/docs/db.md
+++ b/docs/db.md
@@ -1,13 +1,14 @@
-## DB cluster info
+# DB cluster info
 See the [script](../scripts/report-rds-cluster-key-attributes.sh)
 - Each cluster node has a different maintenance window
 	- Since we use a module to create/manage the RDS cluster, we cannot set this
 
 
-## Connecting to the DB
+
+# Connecting to the DB
 Connection to the bastion as described [here](./bastion.md)
 
-### Connection values
+## Connection values
 Writer host is in the prefix-db_host parameter
 ```
 ./scripts/aws-parameters.sh values dev-xyz-db_host
@@ -18,43 +19,170 @@ Database name is in the prefix-db_database parameter
 ./scripts/aws-parameters.sh values dev-xyz-db_database
 ```
 
-Credentials are in the prefix-rds secret
+Credentials are in the prefix-rds secrets - Will be 3 of them
 ```
 ./scripts/aws-secrets.sh values dev-xyz-rds
 ```
 
-
-### Connect
+## Connecting
 Connect with
 ```
-psql -h xyz-dev-rds.cluster-cbbm7etlo64v.eu-west-1.rds.amazonaws.com -U rds_admin_user -d ni
+psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U rds_admin_user -d xyz
 ```
 
 
-## PENDING - Need to work this out
-## Create reader and crud users as needed by QA
-Switch to postgres db
-```
-\c postgres
-```
 
-Create users granting access to the DB
-```
-CREATE USER reader WITH ENCRYPTED PASSWORD 'yourpass';
-GRANT CONNECT ON DATABASE ni TO reader;
+# Extensions configuration
+Need to create the pgcrypto extension as the master user, seems you cannot/should not grant access to creating this to mormal users, see [here](https://dba.stackexchange.com/questions/175319/postgresql-enabling-extensions-without-super-user)
 
-CREATE USER crud WITH ENCRYPTED PASSWORD 'yourpass';
-GRANT CONNECT ON DATABASE ni TO crud;
+## Connect with
+```
+psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U rds_admin_user -d xyz
 ```
 
-Allow user privs on the DB
+## Apply
+```sql
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
 ```
-\c ni
-GRANT USAGE ON SCHEMA public TO reader;
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO reader;
-GRANT SELECT ON ALL SEQUENCES IN SCHEMA public TO reader;
 
 
-GRANT USAGE ON SCHEMA public TO crud;
-GRANT ?? in SCHEMA public TO crud;
+
+# Create roles/users
+## Create roles/users granting access to the DB
+* Read Write Create
+* Read Write
+* Read Only
+
+We do this using the **rds_admin_user**
+
+## Connect with
+```
+psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U rds_admin_user -d xyz
+```
+
+## Apply
+```sql
+# read_write_create role/user
+CREATE ROLE read_write_create;
+
+# Note we add a GRANT here
+GRANT ALL PRIVILEGES ON DATABASE REPLACE-ME-DATABASE-NAME TO read_write_create;
+
+CREATE USER read_write_create_user WITH PASSWORD 'REPLACE-ME';
+
+GRANT read_write_create TO read_write_create_user;
+
+
+# read_write role/user
+CREATE ROLE read_write;
+
+GRANT CONNECT ON DATABASE REPLACE-ME-DATABASE-NAME TO read_write;
+
+CREATE USER read_write_user WITH PASSWORD 'REPLACE-ME-2';
+
+GRANT read_write TO read_write_user;
+
+
+# read_only role/user
+CREATE ROLE read_only;
+
+GRANT CONNECT ON DATABASE REPLACE-ME-DATABASE-NAME TO read_only;
+
+CREATE USER read_only_user WITH PASSWORD 'REPLACE-ME';
+
+GRANT read_only TO read_only_user;
+```
+
+## Grant privs to the read_write and read_only roles
+We do this using the **read_write_create_user** which will be used for migrations and will therefore own the DB objects
+
+### Connect
+```
+psql -h xyz-dev-rds.cluster-something.eu-west-1.rds.amazonaws.com -U read_write_create_user -d xyz
+```
+
+### Apply
+```sql
+# read_write
+GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON ALL TABLES IN SCHEMA public TO read_write;
+
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO read_write;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE, TRUNCATE ON TABLES TO read_write;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO read_write;
+
+
+# read_only role/user
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO read_only;
+
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO read_only;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT ON TABLES TO read_only;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT ON SEQUENCES TO read_only;
+```
+
+## Cleanup history
+After exiting the psql session, you can clean your history so the passwords are not on the bastion disk with
+```
+rm ${HOME}/.psql_history
+```
+
+## Existing table modifications if required
+If tables were previously created by rds_admin_user, owner has to be changed:
+
+All tenants:
+```sql
+ALTER TABLE download_batches
+OWNER TO read_write_create_user;
+
+ALTER TABLE check_ins
+OWNER TO read_write_create_user;
+
+ALTER TABLE exposure_export_files
+OWNER TO read_write_create_user;
+
+ALTER TABLE exposures
+OWNER TO read_write_create_user;
+
+ALTER TABLE metrics
+OWNER TO read_write_create_user;
+
+ALTER TABLE metrics_payloads
+OWNER TO read_write_create_user;
+
+ALTER TABLE metrics_requests
+OWNER TO read_write_create_user;
+
+ALTER TABLE migrations
+OWNER TO read_write_create_user;
+
+ALTER TABLE registrations
+OWNER TO read_write_create_user;
+
+ALTER TABLE settings
+OWNER TO read_write_create_user;
+
+ALTER TABLE tokens
+OWNER TO read_write_create_user;
+
+ALTER TABLE upload_batches
+OWNER TO read_write_create_user;
+
+ALTER TABLE upload_tokens
+OWNER TO read_write_create_user;
+
+ALTER TABLE verifications
+OWNER TO read_write_create_user;
+```
+
+Gibraltar specific:
+
+```sql
+ALTER TABLE gibraltar_tracker_migrations
+OWNER TO read_write_create_user;
+
+ALTER TABLE callbacks
+OWNER TO read_write_create_user;
 ```

--- a/docs/operators.md
+++ b/docs/operators.md
@@ -1,0 +1,8 @@
+# Operators
+We create an operators IAM group which allows restricted privileges
+- ReadOnly access
+- Bastion ASG scaling and session connect for the instance
+- Lambda invoke
+
+
+NOTE: We do not manage the membership of this group

--- a/docs/secrets-parameters.md
+++ b/docs/secrets-parameters.md
@@ -10,6 +10,9 @@ Secrets use a prefix ENV-NAMESPACE- in their names.
 	- header-x-secret
 	- jwt
 	- rds
+	- rds-read-only
+	- rds-read-write
+	- rds-read-write-create
 - Some are optional
 	- cct
 	- cso
@@ -20,7 +23,7 @@ Optional secrets need to be added to the option_secrets variable.
 
 You can use the [aws-secrets.sh](../scripts/aws-secrets.sh) script to create secrets.
 
-i.e. For **dev** env and **ni** project namespace
+i.e. For **dev** env and **xyz** project namespace
 ```
 ./scripts/aws-secrets.sh create dev-xyz-device-check 'SOME-VALUE'
 ```
@@ -53,12 +56,12 @@ The format for the secret is as follows:
   "timeDifferenceThresholdMins": MINS
 }
 ```
+
 ##### apkCertificateDigestSha256
 An array of SHA-265 hashes of the certificates used to sign the APK. Can be set to a false value to disable the check.
 
 ##### apkDigestSha256
-The SHA-256 hash of the APK file. Can be set to a false value to disable the check and should be set to false if there are multiple
-supported versions deployed.
+The SHA-256 hash of the APK file. Can be set to a false value to disable the check and should be set to false if there are multiple supported versions deployed.
 
 ##### apkPackageName
 The name of the APK package.
@@ -173,5 +176,14 @@ The format of the secret is as follows:
 {
   "password":"A strong password",
   "username":"rds_admin_user"
+}
+```
+
+The `rds-read-only`, `rds-read-write`, `rds-read-write-create` secrets contains the application RDS credentials.
+The format of the secret is as follows:
+```json
+{
+  "password":"A strong password",
+  "username":"user_name"
 }
 ```

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -31,32 +31,35 @@ data "aws_iam_policy_document" "api_ecs_task_policy" {
   statement {
     actions = ["ssm:GetParameter", "secretsmanager:GetSecretValue"]
     resources = [
-      aws_ssm_parameter.log_level.arn,
-      aws_ssm_parameter.api_port.arn,
       aws_ssm_parameter.api_host.arn,
-      aws_ssm_parameter.cors_origin.arn,
-      aws_ssm_parameter.db_host.arn,
-      aws_ssm_parameter.db_reader_host.arn,
-      aws_ssm_parameter.db_port.arn,
-      aws_ssm_parameter.db_database.arn,
-      aws_ssm_parameter.db_ssl.arn,
-      aws_ssm_parameter.security_exposure_limit.arn,
-      aws_ssm_parameter.security_refresh_token_expiry.arn,
-      aws_ssm_parameter.security_code_lifetime_mins.arn,
-      aws_ssm_parameter.security_token_lifetime_mins.arn,
-      aws_ssm_parameter.metrics_config.arn,
-      aws_ssm_parameter.security_verify_rate_limit_secs.arn,
+      aws_ssm_parameter.api_port.arn,
       aws_ssm_parameter.callback_url.arn,
-      aws_ssm_parameter.upload_token_lifetime_mins.arn,
-      aws_ssm_parameter.s3_assets_bucket.arn,
+      aws_ssm_parameter.certificate_audience.arn,
+      aws_ssm_parameter.cors_origin.arn,
+      aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_reader_host.arn,
+      aws_ssm_parameter.db_ssl.arn,
+      aws_ssm_parameter.default_region.arn,
       aws_ssm_parameter.enable_callback.arn,
       aws_ssm_parameter.enable_check_in.arn,
+      aws_ssm_parameter.enable_legacy_settings.arn,
       aws_ssm_parameter.enable_metrics.arn,
-      aws_ssm_parameter.default_region.arn,
-      data.aws_secretsmanager_secret_version.rds.arn,
+      aws_ssm_parameter.jwt_issuer.arn,
+      aws_ssm_parameter.log_level.arn,
+      aws_ssm_parameter.metrics_config.arn,
+      aws_ssm_parameter.s3_assets_bucket.arn,
+      aws_ssm_parameter.security_code_lifetime_mins.arn,
+      aws_ssm_parameter.security_refresh_token_expiry.arn,
+      aws_ssm_parameter.security_token_lifetime_mins.arn,
+      aws_ssm_parameter.security_verify_rate_limit_secs.arn,
+      aws_ssm_parameter.upload_token_lifetime_mins.arn,
+      data.aws_secretsmanager_secret_version.device_check.arn,
       data.aws_secretsmanager_secret_version.encrypt.arn,
       data.aws_secretsmanager_secret_version.jwt.arn,
-      data.aws_secretsmanager_secret_version.device-check.arn
+      data.aws_secretsmanager_secret_version.rds.arn,
+      data.aws_secretsmanager_secret_version.rds_read_write_create.arn
     ]
   }
 
@@ -90,12 +93,12 @@ resource "aws_iam_role_policy_attachment" "api_ecs_task_policy" {
 # API Service
 # #########################################
 data "template_file" "api_service_container_definitions" {
-  template = file("templates/api_service_task_definition.tpl")
+  template = file(format("%s/templates/api_service_task_definition.tpl", path.module))
 
   vars = {
-    api_image_uri        = "${aws_ecr_repository.api.repository_url}:latest"
+    api_image_uri        = local.ecs_api_image_uri
     config_var_prefix    = local.config_var_prefix
-    migrations_image_uri = "${aws_ecr_repository.migrations.repository_url}:latest"
+    migrations_image_uri = local.ecs_migrations_image_uri
     listening_port       = var.api_listening_port
     logs_service_name    = aws_cloudwatch_log_group.api.name
     log_group_region     = var.aws_region

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -16,21 +16,23 @@ data "aws_iam_policy_document" "push_ecs_task_policy" {
   statement {
     actions = ["ssm:GetParameter", "secretsmanager:GetSecretValue"]
     resources = [
-      aws_ssm_parameter.log_level.arn,
-      aws_ssm_parameter.push_port.arn,
-      aws_ssm_parameter.push_host.arn,
       aws_ssm_parameter.cors_origin.arn,
-      aws_ssm_parameter.db_host.arn,
-      aws_ssm_parameter.db_reader_host.arn,
-      aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_database.arn,
+      aws_ssm_parameter.db_host.arn,
+      aws_ssm_parameter.db_port.arn,
+      aws_ssm_parameter.db_reader_host.arn,
       aws_ssm_parameter.db_ssl.arn,
       aws_ssm_parameter.default_country_code.arn,
+      aws_ssm_parameter.log_level.arn,
+      aws_ssm_parameter.push_host.arn,
+      aws_ssm_parameter.push_port.arn,
       aws_ssm_parameter.security_code_charset.arn,
       aws_ssm_parameter.security_code_length.arn,
+      aws_ssm_parameter.security_code_lifetime_mins.arn,
       aws_ssm_parameter.sms_url.arn,
+      data.aws_secretsmanager_secret_version.jwt.arn,
       data.aws_secretsmanager_secret_version.rds.arn,
-      data.aws_secretsmanager_secret_version.jwt.arn
+      data.aws_secretsmanager_secret_version.rds_read_write.arn
     ]
   }
 
@@ -77,11 +79,11 @@ resource "aws_iam_role_policy_attachment" "push_ecs_task_policy" {
 # Push Service
 # #########################################
 data "template_file" "push_service_container_definitions" {
-  template = file("templates/push_service_task_definition.tpl")
+  template = file(format("%s/templates/push_service_task_definition.tpl", path.module))
 
   vars = {
     config_var_prefix = local.config_var_prefix
-    image_uri         = "${aws_ecr_repository.push.repository_url}:latest"
+    image_uri         = local.ecs_push_image_uri
     listening_port    = var.push_listening_port
     logs_service_name = aws_cloudwatch_log_group.push.name
     log_group_region  = var.aws_region

--- a/env-vars/xyz-dev.tfvars
+++ b/env-vars/xyz-dev.tfvars
@@ -1,8 +1,8 @@
 # Misc
-aws_region   = "eu-west-1"
-environment  = "dev"
-profile      = "xyz-dev"
-root_profile = "xyz-dev"
+aws_region  = "eu-west-1"
+dns_profile = "xyz-dev"
+environment = "dev"
+profile     = "xyz-dev"
 
 # RDS Settings
 rds_backup_retention = 3

--- a/gateway.tf
+++ b/gateway.tf
@@ -172,48 +172,6 @@ resource "aws_api_gateway_integration_response" "api_proxy_any_integration" {
   status_code = aws_api_gateway_method_response.api_proxy_any.status_code
 }
 
-## /api/healthcheck
-resource "aws_api_gateway_resource" "api_healthcheck" {
-  rest_api_id = aws_api_gateway_rest_api.main.id
-  parent_id   = aws_api_gateway_resource.api.id
-  path_part   = "healthcheck"
-}
-
-resource "aws_api_gateway_method" "api_healthcheck_get" {
-  rest_api_id      = aws_api_gateway_rest_api.main.id
-  resource_id      = aws_api_gateway_resource.api_healthcheck.id
-  http_method      = "GET"
-  authorization    = "NONE"
-  api_key_required = false
-}
-
-resource "aws_api_gateway_integration" "api_healthcheck_get_integration" {
-  rest_api_id          = aws_api_gateway_rest_api.main.id
-  resource_id          = aws_api_gateway_resource.api_healthcheck.id
-  http_method          = aws_api_gateway_method.api_healthcheck_get.http_method
-  passthrough_behavior = "WHEN_NO_TEMPLATES"
-  type                 = "MOCK"
-  request_templates = {
-    "application/json" = jsonencode({
-      statusCode = 204
-    })
-  }
-}
-
-resource "aws_api_gateway_method_response" "api_healthcheck_get" {
-  rest_api_id = aws_api_gateway_rest_api.main.id
-  resource_id = aws_api_gateway_resource.api_healthcheck.id
-  http_method = aws_api_gateway_method.api_healthcheck_get.http_method
-  status_code = "204"
-}
-
-resource "aws_api_gateway_integration_response" "api_healthcheck_get_integration" {
-  rest_api_id = aws_api_gateway_rest_api.main.id
-  resource_id = aws_api_gateway_resource.api_healthcheck.id
-  http_method = aws_api_gateway_method.api_healthcheck_get.http_method
-  status_code = aws_api_gateway_method_response.api_healthcheck_get.status_code
-}
-
 ## /api/settings
 resource "aws_api_gateway_resource" "api_settings" {
   rest_api_id = aws_api_gateway_rest_api.main.id
@@ -531,7 +489,6 @@ resource "aws_api_gateway_deployment" "live" {
     aws_api_gateway_integration.root,
     aws_api_gateway_integration.api_proxy_options_integration,
     aws_api_gateway_integration.api_proxy_any_integration,
-    aws_api_gateway_integration.api_healthcheck_get_integration,
     aws_api_gateway_integration.api_settings_get_integration,
     aws_api_gateway_integration.api_settings_exposures_get_integration,
     aws_api_gateway_integration.api_settings_language_get_integration,
@@ -593,4 +550,48 @@ resource "aws_api_gateway_authorizer" "main" {
   rest_api_id            = aws_api_gateway_rest_api.main.id
   authorizer_uri         = coalesce(join("", aws_lambda_alias.authorizer_live.*.invoke_arn), aws_lambda_function.authorizer.invoke_arn)
   authorizer_credentials = aws_iam_role.authorizer.arn
+}
+
+# PENDING: Had to restore this as we had an issue when doing an apply
+#	- Error: Cycle: module.this.aws_api_gateway_stage.live, module.this.aws_api_gateway_resource.api_healthcheck (destroy), module.this.aws_api_gateway_method.api_healthcheck_get (destroy), module.this.aws_api_gateway_deployment.live, module.this.aws_api_gateway_deployment.live (destroy deposed 754a6586), module.this.aws_api_gateway_integration.api_healthcheck_get_integration (destroy)
+## /api/healthcheck
+resource "aws_api_gateway_resource" "api_healthcheck" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  parent_id   = aws_api_gateway_resource.api.id
+  path_part   = "healthcheck"
+}
+
+resource "aws_api_gateway_method" "api_healthcheck_get" {
+  rest_api_id      = aws_api_gateway_rest_api.main.id
+  resource_id      = aws_api_gateway_resource.api_healthcheck.id
+  http_method      = "GET"
+  authorization    = "NONE"
+  api_key_required = false
+}
+
+resource "aws_api_gateway_integration" "api_healthcheck_get_integration" {
+  rest_api_id          = aws_api_gateway_rest_api.main.id
+  resource_id          = aws_api_gateway_resource.api_healthcheck.id
+  http_method          = aws_api_gateway_method.api_healthcheck_get.http_method
+  passthrough_behavior = "WHEN_NO_TEMPLATES"
+  type                 = "MOCK"
+  request_templates = {
+    "application/json" = jsonencode({
+      statusCode = 204
+    })
+  }
+}
+
+resource "aws_api_gateway_method_response" "api_healthcheck_get" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.api_healthcheck.id
+  http_method = aws_api_gateway_method.api_healthcheck_get.http_method
+  status_code = "204"
+}
+
+resource "aws_api_gateway_integration_response" "api_healthcheck_get_integration" {
+  rest_api_id = aws_api_gateway_rest_api.main.id
+  resource_id = aws_api_gateway_resource.api_healthcheck.id
+  http_method = aws_api_gateway_method.api_healthcheck_get.http_method
+  status_code = aws_api_gateway_method_response.api_healthcheck_get.status_code
 }

--- a/lambda-authorizer.tf
+++ b/lambda-authorizer.tf
@@ -57,23 +57,15 @@ resource "aws_iam_role_policy_attachment" "authorizer_logs" {
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
 }
 
-data "aws_secretsmanager_secret" "jwt_secret" {
-  name = "${module.labels.id}-jwt"
-}
-
-data "aws_secretsmanager_secret_version" "jwt_secret" {
-  secret_id = "${data.aws_secretsmanager_secret.jwt_secret.id}"
-}
-
 resource "aws_lambda_function" "authorizer" {
   filename         = "${path.module}/.zip/${module.labels.id}_authorizer.zip"
   function_name    = "${module.labels.id}-authorizer"
   source_code_hash = data.archive_file.authorizer.output_base64sha256
   role             = aws_iam_role.authorizer.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   handler          = "authorizer.handler"
-  memory_size      = 512 # Since this is on the hot path and we get faster CPUs with higher memory
-  timeout          = 15
+  memory_size      = var.lambda_authorizer_memory_size
+  timeout          = var.lambda_authorizer_timeout
   tags             = module.labels.tags
 
   depends_on = [aws_cloudwatch_log_group.authorizer]
@@ -82,7 +74,7 @@ resource "aws_lambda_function" "authorizer" {
     variables = {
       CONFIG_VAR_PREFIX = local.config_var_prefix,
       NODE_ENV          = "production"
-      JWT_SECRET        = jsondecode(data.aws_secretsmanager_secret_version.jwt_secret.secret_string)["key"]
+      JWT_SECRET        = jsondecode(data.aws_secretsmanager_secret_version.jwt.secret_string)["key"]
     }
   }
 

--- a/lambda-callback.tf
+++ b/lambda-callback.tf
@@ -8,10 +8,6 @@ data "aws_iam_policy_document" "callback_policy" {
   statement {
     actions = [
       "s3:*",
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DetachNetworkInterface",
-      "ec2:DeleteNetworkInterface",
       "secretsmanager:GetSecretValue",
       "ssm:GetParameter",
       "sqs:*"
@@ -64,9 +60,9 @@ resource "aws_iam_role_policy_attachment" "callback_policy" {
   policy_arn = aws_iam_policy.callback_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "callback_logs" {
+resource "aws_iam_role_policy_attachment" "callback_aws_managed_policy" {
   role       = aws_iam_role.callback.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_lambda_function" "callback" {
@@ -74,10 +70,10 @@ resource "aws_lambda_function" "callback" {
   function_name    = "${module.labels.id}-callback"
   source_code_hash = data.archive_file.callback.output_base64sha256
   role             = aws_iam_role.callback.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   handler          = "callback.handler"
-  memory_size      = 128
-  timeout          = 15
+  memory_size      = var.lambda_callback_memory_size
+  timeout          = var.lambda_callback_timeout
   tags             = module.labels.tags
 
   depends_on = [aws_cloudwatch_log_group.callback]

--- a/lambda-daily-registrations-reporter.tf
+++ b/lambda-daily-registrations-reporter.tf
@@ -22,14 +22,16 @@ module "daily_registrations_reporter" {
     aws_ssm_parameter.daily_registrations_reporter_email_subject.*.arn,
     aws_ssm_parameter.daily_registrations_reporter_sns_arn.*.arn
   )
-  aws_secret_arns                = [data.aws_secretsmanager_secret_version.rds.arn]
+  aws_secret_arns                = [data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn]
   cloudwatch_schedule_expression = var.daily_registrations_reporter_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "reporter.handler"
   kms_writer_arns                = [aws_kms_key.sns.arn]
   log_retention_days             = var.logs_retention_days
+  memory_size                    = var.lambda_daily_registrations_reporter_memory_size
   security_group_ids             = [module.lambda_sg.id]
   sns_topic_arns_to_publish_to   = aws_sns_topic.daily_registrations_reporter.*.arn
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags
+  timeout                        = var.lambda_daily_registrations_reporter_timeout
 }

--- a/lambda-download.tf
+++ b/lambda-download.tf
@@ -17,12 +17,14 @@ module "download" {
     aws_ssm_parameter.db_reader_host.arn,
     aws_ssm_parameter.db_ssl.arn
   ]
-  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
+  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
   cloudwatch_schedule_expression = var.download_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "download.handler"
   log_retention_days             = var.logs_retention_days
+  memory_size                    = var.lambda_download_memory_size
   security_group_ids             = [module.lambda_sg.id]
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags
+  timeout                        = var.lambda_download_timeout
 }

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -8,10 +8,6 @@ data "aws_iam_policy_document" "exposures_policy" {
   statement {
     actions = [
       "s3:*",
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DetachNetworkInterface",
-      "ec2:DeleteNetworkInterface",
       "secretsmanager:GetSecretValue",
       "ssm:GetParameter"
     ]
@@ -56,9 +52,9 @@ resource "aws_iam_role_policy_attachment" "exposures_policy" {
   policy_arn = aws_iam_policy.exposures_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "exposures_logs" {
+resource "aws_iam_role_policy_attachment" "exposures_aws_managed_policy" {
   role       = aws_iam_role.exposures.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_lambda_function" "exposures" {
@@ -66,10 +62,10 @@ resource "aws_lambda_function" "exposures" {
   function_name    = "${module.labels.id}-exposures"
   source_code_hash = data.archive_file.exposures.output_base64sha256
   role             = aws_iam_role.exposures.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   handler          = "exposures.handler"
-  memory_size      = 128
-  timeout          = 15
+  memory_size      = var.lambda_exposures_memory_size
+  timeout          = var.lambda_exposures_timeout
   tags             = module.labels.tags
 
   depends_on = [aws_cloudwatch_log_group.exposures]

--- a/lambda-settings.tf
+++ b/lambda-settings.tf
@@ -8,10 +8,6 @@ data "aws_iam_policy_document" "settings_policy" {
   statement {
     actions = [
       "s3:*",
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DetachNetworkInterface",
-      "ec2:DeleteNetworkInterface",
       "secretsmanager:GetSecretValue",
       "ssm:GetParameter"
     ]
@@ -56,9 +52,9 @@ resource "aws_iam_role_policy_attachment" "settings_policy" {
   policy_arn = aws_iam_policy.settings_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "settings_logs" {
+resource "aws_iam_role_policy_attachment" "settings_aws_managed_policy" {
   role       = aws_iam_role.settings.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_lambda_function" "settings" {
@@ -66,10 +62,10 @@ resource "aws_lambda_function" "settings" {
   function_name    = "${module.labels.id}-settings"
   source_code_hash = data.archive_file.settings.output_base64sha256
   role             = aws_iam_role.settings.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   handler          = "settings.handler"
-  memory_size      = 128
-  timeout          = 15
+  memory_size      = var.lambda_settings_memory_size
+  timeout          = var.lambda_settings_timeout
   tags             = module.labels.tags
 
   depends_on = [aws_cloudwatch_log_group.settings]

--- a/lambda-sms.tf
+++ b/lambda-sms.tf
@@ -23,16 +23,18 @@ module "sms" {
     aws_ssm_parameter.sms_template.arn,
     aws_ssm_parameter.sms_url.arn
   ]
-  aws_secret_arns                            = concat([data.aws_secretsmanager_secret_version.rds.arn], data.aws_secretsmanager_secret_version.sms.*.arn)
+  aws_secret_arns                            = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.sms.*.arn)
   config_var_prefix                          = local.config_var_prefix
   enable_sns_publish_for_sms_without_a_topic = var.enable_sms_publishing_with_aws
   handler                                    = "sms.handler"
   kms_reader_arns                            = [aws_kms_key.sqs.arn]
   log_retention_days                         = var.logs_retention_days
+  memory_size                                = var.lambda_sms_memory_size
   security_group_ids                         = [module.lambda_sg.id]
   sqs_queue_arns_to_consume_from             = [aws_sqs_queue.sms.arn]
   subnet_ids                                 = module.vpc.private_subnets
   tags                                       = module.labels.tags
+  timeout                                    = var.lambda_sms_timeout
 }
 
 # Cannot create this in the module, will get a plan issue

--- a/lambda-stats.tf
+++ b/lambda-stats.tf
@@ -8,10 +8,6 @@ data "aws_iam_policy_document" "stats_policy" {
   statement {
     actions = [
       "s3:*",
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DetachNetworkInterface",
-      "ec2:DeleteNetworkInterface",
       "secretsmanager:GetSecretValue",
       "ssm:GetParameter"
     ]
@@ -56,9 +52,9 @@ resource "aws_iam_role_policy_attachment" "stats_policy" {
   policy_arn = aws_iam_policy.stats_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "stats_logs" {
+resource "aws_iam_role_policy_attachment" "stats_aws_managed_policy" {
   role       = aws_iam_role.stats.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_lambda_function" "stats" {
@@ -66,10 +62,10 @@ resource "aws_lambda_function" "stats" {
   function_name    = "${module.labels.id}-stats"
   source_code_hash = data.archive_file.stats.output_base64sha256
   role             = aws_iam_role.stats.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   handler          = "stats.handler"
-  memory_size      = 128
-  timeout          = 15
+  memory_size      = var.lambda_stats_memory_size
+  timeout          = var.lambda_stats_timeout
   tags             = module.labels.tags
 
   depends_on = [aws_cloudwatch_log_group.stats]

--- a/lambda-token.tf
+++ b/lambda-token.tf
@@ -8,10 +8,6 @@ data "aws_iam_policy_document" "token_policy" {
   statement {
     actions = [
       "s3:*",
-      "ec2:CreateNetworkInterface",
-      "ec2:DescribeNetworkInterfaces",
-      "ec2:DetachNetworkInterface",
-      "ec2:DeleteNetworkInterface",
       "secretsmanager:GetSecretValue",
       "ssm:GetParameter"
     ]
@@ -56,9 +52,9 @@ resource "aws_iam_role_policy_attachment" "token_policy" {
   policy_arn = aws_iam_policy.token_policy.arn
 }
 
-resource "aws_iam_role_policy_attachment" "token_logs" {
+resource "aws_iam_role_policy_attachment" "token_aws_managed_policy" {
   role       = aws_iam_role.token.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }
 
 resource "aws_lambda_function" "token" {
@@ -66,10 +62,10 @@ resource "aws_lambda_function" "token" {
   function_name    = "${module.labels.id}-token"
   source_code_hash = data.archive_file.token.output_base64sha256
   role             = aws_iam_role.token.arn
-  runtime          = "nodejs10.x"
+  runtime          = "nodejs12.x"
   handler          = "token.handler"
-  memory_size      = 128
-  timeout          = 15
+  memory_size      = var.lambda_token_memory_size
+  timeout          = var.lambda_token_timeout
   tags             = module.labels.tags
 
   depends_on = [aws_cloudwatch_log_group.token]

--- a/lambda-upload.tf
+++ b/lambda-upload.tf
@@ -17,12 +17,14 @@ module "upload" {
     aws_ssm_parameter.db_reader_host.arn,
     aws_ssm_parameter.db_ssl.arn
   ]
-  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
+  aws_secret_arns                = concat([data.aws_secretsmanager_secret_version.rds.arn, data.aws_secretsmanager_secret_version.rds_read_write.arn], data.aws_secretsmanager_secret_version.interop.*.arn)
   cloudwatch_schedule_expression = var.upload_schedule
   config_var_prefix              = local.config_var_prefix
   handler                        = "upload.handler"
   log_retention_days             = var.logs_retention_days
+  memory_size                    = var.lambda_upload_memory_size
   security_group_ids             = [module.lambda_sg.id]
   subnet_ids                     = module.vpc.private_subnets
   tags                           = module.labels.tags
+  timeout                        = var.lambda_upload_timeout
 }

--- a/locals.tf
+++ b/locals.tf
@@ -2,7 +2,7 @@
 # Locals
 # #########################################
 locals {
-  # Pick one, using the var if it is set, else failback to the one we maanage
+  # Pick one, using the var if it is set, else failback to the one we manage
   alb_push_certificate_arn = coalesce(var.push_eu_certificate_arn, join("", aws_acm_certificate.wildcard_cert.*.arn))
 
   # Based on flag
@@ -13,6 +13,11 @@ locals {
 
   # Will be used as a prefix for AWS parameters and secrets
   config_var_prefix = "${module.labels.id}-"
+
+  # ECS image values
+  ecs_api_image_uri        = coalesce(var.api_image_repo_url, format("%s:%s", aws_ecr_repository.api.repository_url, var.api_image_tag))
+  ecs_migrations_image_uri = coalesce(var.migrations_image_repo_url, format("%s:%s", aws_ecr_repository.migrations.repository_url, var.migrations_image_tag))
+  ecs_push_image_uri       = coalesce(var.push_image_repo_url, format("%s:%s", aws_ecr_repository.push.repository_url, var.push_image_tag))
 
   # Based on flag
   enable_certificates_count = var.enable_certificates ? 1 : 0
@@ -26,10 +31,9 @@ locals {
   # PENDING: Revisit this
   # Need to only create one of these for an account/region
   # Logic is all the dev envs are in a single account, and assumes all the other envs are in a dedicated account/region
-  # Want to only create one of these
-  gateway_api_account_count = (var.environment == "dev" && var.namespace == "xyz") || var.environment != "dev" ? 1 : 0
+  gateway_api_account_count = (var.environment == "dev" && var.namespace == "fight-together") || var.environment != "dev" ? 1 : 0
 
-  # Pick one, using the var if it is set, else failback to the one we maanage
+  # Pick one, using the var if it is set, else failback to the one we manage
   gateway_api_certificate_arn = coalesce(var.api_us_certificate_arn, join("", aws_acm_certificate.wildcard_cert_us.*.arn))
 
   # Based on either of DNS enabled OR (We have an api_dns AND and api_us_certificate_arn)
@@ -48,7 +52,7 @@ locals {
   waf_geo_blocking_count = length(var.waf_geo_allowed_countries) > 0 ? 1 : 0
 
   # This is required as we use the count as toggle:
-  cloudtrail_log_group_name = "${join(" ", aws_cloudwatch_log_group.cloudtrail.*.name)}"
+  cloudtrail_log_group_name = join(" ", aws_cloudwatch_log_group.cloudtrail.*.name)
   # Cloudtrail log stream related:
   cloudtrail_log_stream_arn_pattern = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:log-group:${local.cloudtrail_log_group_name}:log-stream:${data.aws_caller_identity.current.account_id}_CloudTrail_${var.aws_region}*"
 }

--- a/main.tf
+++ b/main.tf
@@ -3,38 +3,40 @@
 # #########################################
 terraform {
   required_version = ">= 0.12.29"
+
+  # Leaving this, even though we have moved towards using this repo as a module - will ignore in that case
+  # Also need to cater for git submodule/subtree usage for existing infrastructure
   backend "s3" {}
 }
 
 # #########################################
-# AWS provider
+# AWS providers
 # #########################################
+# Main provider
 provider "aws" {
   version = "2.68.0"
   region  = var.aws_region
   profile = var.profile
 }
 
+# Provider based on main but using us_east_1 as region
+# Will use this if creating a TLS certificate in us-east-1 region as required by CloudFront Edge used by the APIGateway
 provider "aws" {
   version = "2.68.0"
-  alias   = "us"
+  alias   = "us_east_1"
   region  = "us-east-1"
   profile = var.profile
 }
 
+# DNS provider
+# Will use this if managing DNS, in some cases the Route53 zones are managed on a different account
 provider "aws" {
   version = "2.68.0"
-  alias   = "root"
+  alias   = "dns"
   region  = var.aws_region
-  profile = var.root_profile
+  profile = var.dns_profile
 }
 
-provider "aws" {
-  version = "2.68.0"
-  alias   = "root-us"
-  region  = "us-east-1"
-  profile = var.root_profile
-}
 
 # #########################################
 # Other providers

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,14 @@ terraform {
   # Leaving this, even though we have moved towards using this repo as a module - will ignore in that case
   # Also need to cater for git submodule/subtree usage for existing infrastructure
   backend "s3" {}
+
+  # Providers
+  required_providers {
+    archive = "~> 1.3.0"
+    aws     = "~> 2.70"
+    null    = "~> 2.1"
+    random  = "~> 2.0"
+  }
 }
 
 # #########################################
@@ -14,7 +22,6 @@ terraform {
 # #########################################
 # Main provider
 provider "aws" {
-  version = "2.68.0"
   region  = var.aws_region
   profile = var.profile
 }
@@ -22,7 +29,6 @@ provider "aws" {
 # Provider based on main but using us_east_1 as region
 # Will use this if creating a TLS certificate in us-east-1 region as required by CloudFront Edge used by the APIGateway
 provider "aws" {
-  version = "2.68.0"
   alias   = "us_east_1"
   region  = "us-east-1"
   profile = var.profile
@@ -31,7 +37,6 @@ provider "aws" {
 # DNS provider
 # Will use this if managing DNS, in some cases the Route53 zones are managed on a different account
 provider "aws" {
-  version = "2.68.0"
   alias   = "dns"
   region  = var.aws_region
   profile = var.dns_profile
@@ -39,29 +44,10 @@ provider "aws" {
 
 
 # #########################################
-# Other providers
-# #########################################
-provider "null" {
-  version = "~> 2.1"
-}
-
-provider "template" {
-  version = "~> 2.1"
-}
-
-provider "random" {
-  version = "~> 2.0"
-}
-
-provider "archive" {
-  version = "~> 1.3.0"
-}
-
-# #########################################
 # Data
 # #########################################
-data "aws_caller_identity" "current" {}
-
 data "aws_availability_zones" "available" {
   state = "available"
 }
+
+data "aws_caller_identity" "current" {}

--- a/modules/lambda/main.tf
+++ b/modules/lambda/main.tf
@@ -60,7 +60,7 @@ variable "name" {
 }
 
 variable "runtime" {
-  default = "nodejs10.x"
+  default = "nodejs12.x"
 }
 
 variable "security_group_ids" {

--- a/operators.tf
+++ b/operators.tf
@@ -14,7 +14,9 @@ data "aws_iam_policy_document" "operators" {
       aws_lambda_function.settings.arn,
       aws_lambda_function.token.arn
       ],
-    aws_lambda_function.cso.*.arn)
+      aws_lambda_function.cso.*.arn,
+      compact([module.daily_registrations_reporter.function_arn, module.download.function_arn, module.upload.function_arn])
+    )
   }
 
   # Explicitly deny anything on authorizer as it contains a secret

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,14 @@
-output "api_aws_dns" {
-  value = join("", aws_api_gateway_domain_name.main.*.cloudfront_domain_name)
-}
-
-
 output "admins_role_arn" {
   description = "ARN of the role used for admins"
   value       = aws_iam_role.admins.arn
 }
 
+output "api_aws_dns" {
+  value = join("", aws_api_gateway_domain_name.main.*.cloudfront_domain_name)
+}
+
 output "cloudtrail_log_group_name" {
-  value = "${join(" ", aws_cloudwatch_log_group.cloudtrail.*.name)}"
+  value = join(" ", aws_cloudwatch_log_group.cloudtrail.*.name)
 }
 
 output "ecs_cluster_api_service_name" {
@@ -84,6 +83,14 @@ output "rds_cluster_identifier" {
   value = module.rds_cluster_aurora_postgres.cluster_identifier
 }
 
+output "rds_endpoint" {
+  value = module.rds_cluster_aurora_postgres.endpoint
+}
+
+output "rds_reader_endpoint" {
+  value = module.rds_cluster_aurora_postgres.reader_endpoint
+}
+
 output "secret" {
   value = aws_iam_access_key.ci_user.secret
 }
@@ -92,10 +99,10 @@ output "vpc_id" {
   value = module.vpc.vpc_id
 }
 
-output "waf_acl_name" {
-  value = aws_wafregional_web_acl.acl.name
-}
-
 output "waf_acl_metric_name" {
   value = aws_wafregional_web_acl.acl.metric_name
+}
+
+output "waf_acl_name" {
+  value = aws_wafregional_web_acl.acl.name
 }

--- a/parameters.tf
+++ b/parameters.tf
@@ -113,11 +113,35 @@ resource "aws_ssm_parameter" "enable_check_in" {
   tags      = module.labels.tags
 }
 
+resource "aws_ssm_parameter" "enable_legacy_settings" {
+  overwrite = true
+  name      = "${local.config_var_prefix}enable_legacy_settings"
+  type      = "String"
+  value     = var.enable_legacy_settings
+  tags      = module.labels.tags
+}
+
 resource "aws_ssm_parameter" "enable_metrics" {
   overwrite = true
   name      = "${local.config_var_prefix}enable_metrics"
   type      = "String"
   value     = var.enable_metrics
+  tags      = module.labels.tags
+}
+
+resource "aws_ssm_parameter" "certificate_audience" {
+  overwrite = true
+  name      = "${local.config_var_prefix}certificate_audience"
+  type      = "String"
+  value     = "${module.labels.id}-api"
+  tags      = module.labels.tags
+}
+
+resource "aws_ssm_parameter" "jwt_issuer" {
+  overwrite = true
+  name      = "${local.config_var_prefix}jwt_issuer"
+  type      = "String"
+  value     = "${module.labels.id}-api"
   tags      = module.labels.tags
 }
 
@@ -190,14 +214,6 @@ resource "aws_ssm_parameter" "security_code_lifetime_mins" {
   name      = "${local.config_var_prefix}security_code_lifetime_mins"
   type      = "String"
   value     = var.code_lifetime_mins
-  tags      = module.labels.tags
-}
-
-resource "aws_ssm_parameter" "security_exposure_limit" {
-  overwrite = true
-  name      = "${local.config_var_prefix}security_exposure_limit"
-  type      = "String"
-  value     = var.exposure_limit
   tags      = module.labels.tags
 }
 

--- a/remove-me-later.tf
+++ b/remove-me-later.tf
@@ -1,0 +1,15 @@
+## REMOVE THESE AFTER APPLIES ON ALL ENVS
+## We keep this to allow the transition to be made in the state file, if we renamed the plan would balk indicating a missing provider
+provider "aws" {
+  version = "2.68.0"
+  alias   = "us"
+  region  = "us-east-1"
+  profile = var.profile
+}
+
+provider "aws" {
+  version = "2.68.0"
+  alias   = "root"
+  region  = var.aws_region
+  profile = var.dns_profile
+}

--- a/remove-me-later.tf
+++ b/remove-me-later.tf
@@ -1,15 +1,18 @@
 ## REMOVE THESE AFTER APPLIES ON ALL ENVS
 ## We keep this to allow the transition to be made in the state file, if we renamed the plan would balk indicating a missing provider
 provider "aws" {
-  version = "2.68.0"
   alias   = "us"
   region  = "us-east-1"
   profile = var.profile
 }
 
 provider "aws" {
-  version = "2.68.0"
   alias   = "root"
   region  = var.aws_region
   profile = var.dns_profile
+}
+
+## We keep this till we have applied all the way to prod and state files are updated
+provider "template" {
+  version = "~> 2.1"
 }

--- a/scripts/aws-parameters.sh
+++ b/scripts/aws-parameters.sh
@@ -20,7 +20,7 @@ list() {
 values() {
 	prefix=${1:-}
 	for name in $(list "${prefix}"); do
- 		value=$(aws ssm get-parameter --name ${name} --with-decryption --output json | jq -r .Parameter.Value)
+		value=$(aws ssm get-parameter --name ${name} --with-decryption --output json | jq -r .Parameter.Value)
 		echo -e "${green_text}${name}${reset_text}\n${value}\n"
 	done
 }

--- a/scripts/aws-secrets.sh
+++ b/scripts/aws-secrets.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# Assumes you have set your AWS_PROFILE or credentials - including the region
 #	./aws-secrets.sh list
 #	./aws-secrets.sh list dev-xyz-
 #
@@ -33,7 +34,7 @@ list() {
 values() {
 	prefix=${1:-}
 	for name in $(list "${prefix}"); do
- 		value=$(aws secretsmanager get-secret-value --output json --secret-id ${name} | jq -r .SecretString)
+		value=$(aws secretsmanager get-secret-value --secret-id ${name} --output json | jq -r .SecretString)
 		echo -e "${green_text}${name}${reset_text}\n${value}\n"
 	done
 }

--- a/scripts/create-infra-ci-user.sh
+++ b/scripts/create-infra-ci-user.sh
@@ -7,6 +7,7 @@
 #
 # Usage is
 #	./create-infra-ci-user.sh dev-xyz
+#	./create-infra-ci-user.sh dev-abc
 #	./create-infra-ci-user.sh prod-xyz
 #
 set -eou pipefail

--- a/scripts/create-tf-state-backend.sh
+++ b/scripts/create-tf-state-backend.sh
@@ -18,34 +18,36 @@ set -eou pipefail
 aws_region=${1}
 s3_bucket_name=${2}
 dynamodb_table_name=${3}
-location_constraint="LocationConstraint=${aws_region}"
 
-if [ "$aws_region" = "us-east-1" ]; then
-    # us-east-1 is a special case per AWS.
-    location_constraint=""
-fi
 
 # S3 bucket
 # Create bucket
-aws s3api create-bucket --bucket ${s3_bucket_name} \
-    --region ${aws_region} \
-    --create-bucket-configuration $location_constraint
+# us-east-1 is a special case where you cannot specify a location contraint, see https://github.com/boto/boto3/issues/125
+if [[ ${aws_region} == "us-east-1" ]]; then
+	aws s3api create-bucket --bucket ${s3_bucket_name} \
+		--region ${aws_region}
+else
+	aws s3api create-bucket --bucket ${s3_bucket_name} \
+		--region ${aws_region} \
+		--create-bucket-configuration LocationConstraint=${aws_region}
+fi
 # Encrypt bucket
 aws s3api put-bucket-encryption \
-    --bucket ${s3_bucket_name} \
-    --server-side-encryption-configuration='{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
+	--bucket ${s3_bucket_name} \
+	--server-side-encryption-configuration='{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}'
 # Apply versioning
 aws s3api put-bucket-versioning --bucket ${s3_bucket_name} --versioning-configuration Status=Enabled
 # Apply block public access config
 aws s3api put-public-access-block \
-    --bucket ${s3_bucket_name} \
-    --public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true" \
+	--bucket ${s3_bucket_name} \
+	--public-access-block-configuration "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true" \
 
 
 # DynamoDb table
 # Create table
 aws dynamodb create-table \
-    --table-name ${dynamodb_table_name} \
-    --attribute-definitions AttributeName=LockID,AttributeType=S \
-    --key-schema AttributeName=LockID,KeyType=HASH \
-    --billing-mode PAY_PER_REQUEST
+	--table-name ${dynamodb_table_name} \
+	--attribute-definitions AttributeName=LockID,AttributeType=S \
+	--key-schema AttributeName=LockID,KeyType=HASH \
+	--billing-mode PAY_PER_REQUEST \
+	--region ${aws_region}

--- a/scripts/report-rds-cluster-key-attributes.sh
+++ b/scripts/report-rds-cluster-key-attributes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eou pipefail
 
-cluster_identifier=${1:-xyz-dev-rds}
+cluster_identifier=${1:-fight-together-dev-rds}
 
 cluster_attributes='DatabaseName Engine EngineVersion PreferredBackupWindow PreferredMaintenanceWindow'
 db_instance_attributes='DBInstanceClass PreferredBackupWindow AvailabilityZone PreferredMaintenanceWindow MonitoringInterval Endpoint.Address Endpoint.Port'

--- a/secrets.tf
+++ b/secrets.tf
@@ -5,7 +5,7 @@ data "aws_secretsmanager_secret_version" "api_gateway_header" {
   secret_id = "${local.config_var_prefix}header-x-secret"
 }
 
-data "aws_secretsmanager_secret_version" "device-check" {
+data "aws_secretsmanager_secret_version" "device_check" {
   secret_id = "${local.config_var_prefix}device-check"
 }
 
@@ -23,6 +23,18 @@ data "aws_secretsmanager_secret_version" "jwt" {
 
 data "aws_secretsmanager_secret_version" "rds" {
   secret_id = "${local.config_var_prefix}rds"
+}
+
+data "aws_secretsmanager_secret_version" "rds_read_only" {
+  secret_id = "${local.config_var_prefix}rds-read-only"
+}
+
+data "aws_secretsmanager_secret_version" "rds_read_write" {
+  secret_id = "${local.config_var_prefix}rds-read-write"
+}
+
+data "aws_secretsmanager_secret_version" "rds_read_write_create" {
+  secret_id = "${local.config_var_prefix}rds-read-write-create"
 }
 
 # #########################################

--- a/variables.tf
+++ b/variables.tf
@@ -1,12 +1,12 @@
 # #########################################
 # Misc
 # #########################################
-variable "namespace" {}
-variable "full_name" {}
-variable "environment" {}
-variable "profile" {}
-variable "root_profile" {}
 variable "aws_region" {}
+variable "dns_profile" {}
+variable "environment" {}
+variable "full_name" {}
+variable "namespace" {}
+variable "profile" {}
 
 
 # #########################################
@@ -115,6 +115,9 @@ variable "wildcard_domain" {}
 variable "bastion_enabled" {
   default = true
 }
+variable "bastion_asg_desired_count" {
+  default = 0
+}
 
 # #########################################
 # SMS using AWS - used by the SMS lambda
@@ -144,6 +147,30 @@ variable "admins_role_require_mfa" {
 # #########################################
 # API & Lambda - Settings & Env vars
 # #########################################
+variable "api_image_repo_url" {
+  description = "ECR image repo to be deployed into ECS for the API container, includes the tag"
+  default     = ""
+}
+variable "api_image_tag" {
+  description = "ECR image tag to be deployed into ECS for the API container"
+  default     = "latest"
+}
+variable "migrations_image_repo_url" {
+  description = "ECR image repo to be deployed into ECS for the Migration container, includes the tag"
+  default     = ""
+}
+variable "migrations_image_tag" {
+  description = "ECR image tag to be deployed into ECS for the Migration container"
+  default     = "latest"
+}
+variable "push_image_repo_url" {
+  description = "ECR image repo to be deployed into ECS for the Push API container, includes the tag"
+  default     = ""
+}
+variable "push_image_tag" {
+  description = "ECR image tag to be deployed into ECS for the Push API container"
+  default     = "latest"
+}
 variable "api_listening_port" {
   default = 5000
 }
@@ -202,9 +229,6 @@ variable "log_level" {}
 variable "arcgis_url" {
   default = ""
 }
-variable "exposure_limit" {
-  default = "10"
-}
 variable "daily_registrations_reporter_email_subject" {
   default = ""
 }
@@ -234,7 +258,7 @@ variable "upload_token_lifetime_mins" {
   default = "1440"
 }
 variable "metrics_config" {
-  default = "{ \"CONTACT_UPLOAD\": 60, \"CHECK_IN\": 60, \"FORGET\": 60, \"TOKEN_RENEWAL\": 60, \"CALLBACK_OPTIN\": 60, \"CALLBACK_REQUEST\": 60, \"DAILY_ACTIVE_TRACE\": 60, \"CONTACT_NOTIFICATION\": 60 }"
+  default = "{ \"CONTACT_UPLOAD\": 60, \"CHECK_IN\": 60, \"FORGET\": 60, \"TOKEN_RENEWAL\": 60, \"CALLBACK_OPTIN\": 60, \"DAILY_ACTIVE_TRACE\": 60, \"CONTACT_NOTIFICATION\": 60 }"
 }
 variable "verify_rate_limit_secs" {}
 variable "push_listening_port" {
@@ -282,6 +306,9 @@ variable "enable_callback" {
 variable "enable_check_in" {
   default = "true"
 }
+variable "enable_legacy_settings" {
+  default = "false"
+}
 variable "enable_metrics" {
   default = "true"
 }
@@ -291,8 +318,74 @@ variable "default_country_code" {
 variable "default_region" {
   default = ""
 }
+variable "lambda_authorizer_memory_size" {
+  default = 512 # Since this is on the hot path and we get faster CPUs with higher memory
+}
+variable "lambda_authorizer_timeout" {
+  default = 15
+}
+variable "lambda_callback_memory_size" {
+  default = 128
+}
+variable "lambda_callback_timeout" {
+  default = 15
+}
+variable "lambda_cso_memory_size" {
+  default = 3008
+}
+variable "lambda_cso_timeout" {
+  default = 900
+}
+variable "lambda_daily_registrations_reporter_memory_size" {
+  default = 128
+}
+variable "lambda_daily_registrations_reporter_timeout" {
+  default = 15
+}
+variable "lambda_download_memory_size" {
+  default = 128
+}
+variable "lambda_download_timeout" {
+  default = 15
+}
+variable "lambda_exposures_memory_size" {
+  default = 128
+}
+variable "lambda_exposures_timeout" {
+  default = 15
+}
+variable "lambda_settings_memory_size" {
+  default = 128
+}
+variable "lambda_settings_timeout" {
+  default = 15
+}
+variable "lambda_sms_memory_size" {
+  default = 128
+}
 variable "lambda_provisioned_concurrencies" {
   default = {}
+}
+variable "lambda_sms_timeout" {
+  default = 15
+}
+variable "lambda_stats_memory_size" {
+  default = 256
+}
+variable "lambda_stats_timeout" {
+  default = 120
+}
+variable "lambda_token_memory_size" {
+  default = 128
+}
+variable "lambda_token_timeout" {
+  default = 15
+}
+variable "lambda_upload_memory_size" {
+  default = 128
+}
+variable "lambda_upload_timeout" {
+  default = 15
 }
 variable "native_regions" {
   default = ""


### PR DESCRIPTION
- Added: Added ability to set ECS image url and image tag overrides, this is based on @segfault's PR at https://github.com/covidgreen/covid-green-infra/pull/4
- Updated: Switched lambdas from using the AWSLambdaBasicExecutionRole to AWSLambdaVPCAccessExecutionRole managed policy
- Updated: Renamed the "root_profile" var and "root" AWS provider to "dns" as this is confusing, removed a redundant aws provider "root_us"
- Updated: Added changes @segfault added re explicit usage of the AWS CLI `--output json` usage in some of the scripts
- Removed: Removed Terraform validate from the pre-commit hook config as this is being used as a module, have left the s3 backend config for now
- Updated: Switched all the lambdas from nodejs10.x to nodejs12.x
- Added: Use variables for the lambda memory size and timeout attributes with defaults, so we can configure via env-vars files
- Removed: Extracted cti, gct and ni content into specific repos - Will not be managed by this repo
- Added: Added new AWS parameters certificate_audience and jwt_issuer and removed security_exposure_limit AWS parameter
- Added: Docs on the 2 approaches to managing a project - external to this repo and internal to this repo
- Added: Added RDS reader/writer endpoint outputs
- Added: Surfaced bastion ASG desired count as a variable, will need when we use this repo as a module
- Added: Switched to using path.module prefixes for the CloudWatch dashboard template and the ECS container defintion templates
- Fixed: Changed the create TF store backend script to cater for us-east-1 being a special case - Location constraints
- Fixed: Replace all refs to cti, gct and ni with xyz in docs and shell script comments - this is just prep for the open source branch
- Added: Added the following optional lambdas to the operators group execute list: daily-registrations-reporter, download and upload
- Added: Pre-commit hook to include TF fmt, validation and linting
- Fixed: Linting issues - no logic
- Added: Split RDS user usage so we no longer need to use the master credentials


From now on, we will have more atomic PRs.