### PR TITLE
update current to v0.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: New "api_gateway_minimum_compression_size" to allow compression configuration on the APIGateway
+- Added: New variables to control ECS scaling adjustments
+	- api_ecs_autoscale_scale_down_adjustment
+	- api_ecs_autoscale_scale_up_adjustment
+	- push_ecs_autoscale_scale_down_adjustment
+	- push_ecs_autoscale_scale_up_adjustment
 
 
 ## [v0.1.7] 2020-09-17
@@ -16,7 +22,7 @@ All notable changes to this project will be documented in this file.
 - Added: Added "db_pool_size" variable to control pg max pool size - Can be used by ECS API and ECS Push services
 - Updated: Allow stats lambda to access "time_zone" parameter
 - Updated: Added additional resources to the operators group policy for MFA
-- Fix: Adjusted values displayed in the CloudWatch dashboard, so take into consideration doubled logs in ApiGateway logs 
+- Fix: Adjusted values displayed in the CloudWatch dashboard, so take into consideration doubled logs in ApiGateway logs
 
 
 ## [v0.1.6] 2020-09-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ All notable changes to this project will be documented in this file.
 	- push_ecs_autoscale_scale_down_adjustment
 	- push_ecs_autoscale_scale_up_adjustment
 - Added: SUPPORT_REQUESTS.md
+- Added: Headers Cache-Control, Pragma, Strict-Transport-Security
+- Changed: Push API TLS 1.2 enforcement
 
 
 ## [v0.1.7] 2020-09-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Added "onset_date_mandatory" variable to control whether onsetDate/symptomDate is mandatory
 - Added: New "api_gateway_minimum_compression_size" to allow compression configuration on the APIGateway
 - Added: New variables to control ECS scaling adjustments
 	- api_ecs_autoscale_scale_down_adjustment

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Added "attach_waf" variable to attach/detach WAF to ALB and API Gateway
 - Added: Added "disable_valid_key_check" variable to flag whether to disable check if key is still valid when generating export files
 - Added: Added "variance_offset_mins" variable to add to lifetime of keys to check if they are still valid
 - Added: Added "onset_date_mandatory" variable to control whether onsetDate/symptomDate is mandatory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 	- api_ecs_autoscale_scale_up_adjustment
 	- push_ecs_autoscale_scale_down_adjustment
 	- push_ecs_autoscale_scale_up_adjustment
+- Added: SUPPORT_REQUESTS.md
 
 
 ## [v0.1.7] 2020-09-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 
 ## [Unreleased]
+- Added: Added "disable_valid_key_check" variable to flag whether to disable check if key is still valid when generating export files
+- Added: Added "variance_offset_mins" variable to add to lifetime of keys to check if they are still valid
 - Added: Added "onset_date_mandatory" variable to control whether onsetDate/symptomDate is mandatory
 - Added: New "api_gateway_minimum_compression_size" to allow compression configuration on the APIGateway
 - Added: New variables to control ECS scaling adjustments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 
-## [Unreleased]
+## [v0.1.8] 2020-09-23
 - Added: Added "attach_waf" variable to attach/detach WAF to ALB and API Gateway
 - Added: Added "disable_valid_key_check" variable to flag whether to disable check if key is still valid when generating export files
 - Added: Added "variance_offset_mins" variable to add to lifetime of keys to check if they are still valid

--- a/SUPPORT_REQUESTS.md
+++ b/SUPPORT_REQUESTS.md
@@ -1,0 +1,140 @@
+# Support Requests
+
+Before going live, there are AWS Support requests to be raised.
+
+## ALB Warm-up
+
+### Pre-requisites
+* Business support level
+* Application Load Balancer DNS
+* Expected go-live date and time
+* Tenant application name
+* Anticipated requests/sec that will go through the load balancer 
+
+### Request template
+Subject: Pre-warm production ALB _ALB URL_ 
+
+Severity: General guidance
+
+Category: Elastic Load Balancing (ELB), Other
+
+
+```text
+1. What is the DNS name for the ELB(s) that require manual scaling: 
+_ALB URL_ 
+
+2. Event start date/time (please specify the timezone; UTC is preferred): 
+_DATE/TIME_
+
+3. Event end date/time (please specify the timezone; UTC is preferred) ongoing: 
+For 1 month after the start date
+
+4. Expected percent of traffic going through the ELB that will be using SSL termination: 
+0% TLS is terminated at the APIGateway/Cloudfront which connects to the ALB on 80
+
+5. Anticipated requests/sec that will go through the load balancer: 
+_RATE/SEC_
+
+6. The average amount of data in bytes passing through the ELB per request/response pair: 
+Payloads are small, average is around 3k but will not expect large payloads
+
+7. Number of Availability Zones enabled: 
+3
+
+8. Is the back-end currently scaled to the level it will be during the event: 
+No, using ECS Application Auto Scaling.
+
+9. A description of the traffic pattern you are expecting: 
+Initial intense usage, potentially with sudden ramp-up. Lower but sustained usage over time.
+
+10. A brief description of your use case: 
+This is the back-end API for the _TENANTS APPLICATION NAME_ app. It will have a high-profile launch, with lots of initial traffic as citizens sign up, followed by lower but sustained use over the coming months. Exact numbers are hard to predict but given the high profile and visibility, we need to err on the side of caution.
+
+11. Have you disabled persistent connections (keep-alive) on your backend instances? 
+No
+
+12. Rate of traffic increase. How fast do you expect your traffic to change once your event starts (use days/hours/minutes as appropriate): 
+Potentially full load in a short space of time (e.g. if launch features on a national news bulletin)
+```
+
+## Lambda regional concurrent executions
+
+### Pre-requisites
+* Authorizer lambda ARN
+* Tenant application name
+
+Subject: Limit Increase: Lambda
+
+Severity: Business impairing question
+
+Category: Service Limit Increase, Lambda
+
+```text
+1. Provide the main lambda functions ARNs of this application. What do they do? 
+_AUTHORIZER_LAMBDA_ARN_
+Lambda authorizer for API Gateway.
+
+2. Will these functions be VPC enabled? 
+No.
+
+3. Average transactions per second. 
+100 with a significant spikes up to couple of thousands.
+
+4. Average duration. 
+Estimated average is 100ms
+
+5. Average memory size. 
+512
+
+6. What does the application do? 
+Backend for the _TENANTS APPLICATION NAME_ app.
+
+7. What services does your application depend on? Have they been scaled? 
+Lambda in question does not have dependencies on other services.
+
+8. What are the event sources? 
+API Gateway authorizer.
+
+9. Average TPS for each function with a concurrency reservation. 
+100
+```
+
+## SNS SMS Spent limit
+
+### Pre-requisites
+* Expected spent
+* Tenant country
+* Expected rate of messages to be send
+* Tenant application name
+
+Subject: Limit Increase: SNS
+
+Severity: Business impairing question
+
+Category: Service Limit Increase, SNS
+
+```text
+1. The spending limit you are requesting, in US dollars.
+_EXPECTED SPENT_ (typically <$1000) (see SNS/SMS pricing for calculations)
+
+2. A list of countries in which the recipients of your messages are located.
+_TENANT COUNTRY_
+
+3. Information about the type of messages you will be sending (Transactional, Promotional, One-Time Password, etc.)
+OTP
+
+4. The maximum number of messages you expect to send per day.
+_EXPECTED RATE_
+
+5. What is the name of the website, application, or other entity that will be sending SMS messages? Please provide a link.
+_TENANTS APPLICATION NAME_
+
+6. Explain the opt-in process to receive your messages.
+All users that installs the mobile app that decides to notify about infection.
+
+7. Describe the primary function of your site or application and how SMS will be incorporated.
+One time password for reporting confirmed COVID-19 infection.
+
+8. Details of the ways in which you will ensure you are only sending to people who have requested your messages.
+Robust testing of the app.
+```

--- a/alb.tf
+++ b/alb.tf
@@ -162,7 +162,7 @@ resource "aws_lb_listener" "push_https" {
   load_balancer_arn = aws_lb.push.id
   port              = 443
   protocol          = "HTTPS"
-  ssl_policy        = "ELBSecurityPolicy-FS-2018-06"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
   certificate_arn   = local.alb_push_certificate_arn
 
   default_action {

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -47,6 +47,7 @@ data "aws_iam_policy_document" "api_ecs_task_policy" {
       aws_ssm_parameter.enable_check_in.arn,
       aws_ssm_parameter.enable_legacy_settings.arn,
       aws_ssm_parameter.enable_metrics.arn,
+      aws_ssm_parameter.hsts_max_age.arn,
       aws_ssm_parameter.jwt_issuer.arn,
       aws_ssm_parameter.log_level.arn,
       aws_ssm_parameter.metrics_config.arn,

--- a/ecs_api.tf
+++ b/ecs_api.tf
@@ -155,16 +155,18 @@ resource "aws_ecs_service" "api" {
 }
 
 module "api_autoscale" {
-  source                      = "./modules/ecs-autoscale-service"
-  ecs_cluster_resource_name   = aws_ecs_cluster.services.name
-  service_resource_name       = aws_ecs_service.api.name
-  ecs_autoscale_max_instances = var.api_ecs_autoscale_max_instances
-  ecs_autoscale_min_instances = var.api_ecs_autoscale_min_instances
-  ecs_as_cpu_high_threshold   = var.api_cpu_high_threshold
-  ecs_as_cpu_low_threshold    = var.api_cpu_low_threshold
-  ecs_as_mem_high_threshold   = var.api_mem_high_threshold
-  ecs_as_mem_low_threshold    = var.api_mem_low_threshold
-  tags                        = module.labels.tags
+  source                              = "./modules/ecs-autoscale-service"
+  ecs_cluster_resource_name           = aws_ecs_cluster.services.name
+  service_resource_name               = aws_ecs_service.api.name
+  ecs_autoscale_max_instances         = var.api_ecs_autoscale_max_instances
+  ecs_autoscale_min_instances         = var.api_ecs_autoscale_min_instances
+  ecs_autoscale_scale_down_adjustment = var.api_ecs_autoscale_scale_down_adjustment
+  ecs_autoscale_scale_up_adjustment   = var.api_ecs_autoscale_scale_up_adjustment
+  ecs_as_cpu_high_threshold           = var.api_cpu_high_threshold
+  ecs_as_cpu_low_threshold            = var.api_cpu_low_threshold
+  ecs_as_mem_high_threshold           = var.api_mem_high_threshold
+  ecs_as_mem_low_threshold            = var.api_mem_low_threshold
+  tags                                = module.labels.tags
 }
 
 # #########################################

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -26,6 +26,7 @@ data "aws_iam_policy_document" "push_ecs_task_policy" {
       aws_ssm_parameter.default_country_code.arn,
       aws_ssm_parameter.hsts_max_age.arn,
       aws_ssm_parameter.log_level.arn,
+      aws_ssm_parameter.onset_date_mandatory.arn,
       aws_ssm_parameter.push_host.arn,
       aws_ssm_parameter.push_port.arn,
       aws_ssm_parameter.security_code_charset.arn,

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -139,16 +139,18 @@ resource "aws_ecs_service" "push" {
 }
 
 module "push_autoscale" {
-  source                      = "./modules/ecs-autoscale-service"
-  ecs_cluster_resource_name   = aws_ecs_cluster.services.name
-  service_resource_name       = aws_ecs_service.push.name
-  ecs_autoscale_max_instances = var.push_ecs_autoscale_max_instances
-  ecs_autoscale_min_instances = var.push_ecs_autoscale_min_instances
-  ecs_as_cpu_high_threshold   = var.push_cpu_high_threshold
-  ecs_as_cpu_low_threshold    = var.push_cpu_low_threshold
-  ecs_as_mem_high_threshold   = var.push_mem_high_threshold
-  ecs_as_mem_low_threshold    = var.push_mem_low_threshold
-  tags                        = module.labels.tags
+  source                              = "./modules/ecs-autoscale-service"
+  ecs_cluster_resource_name           = aws_ecs_cluster.services.name
+  service_resource_name               = aws_ecs_service.push.name
+  ecs_autoscale_max_instances         = var.push_ecs_autoscale_max_instances
+  ecs_autoscale_min_instances         = var.push_ecs_autoscale_min_instances
+  ecs_autoscale_scale_down_adjustment = var.push_ecs_autoscale_scale_down_adjustment
+  ecs_autoscale_scale_up_adjustment   = var.push_ecs_autoscale_scale_up_adjustment
+  ecs_as_cpu_high_threshold           = var.push_cpu_high_threshold
+  ecs_as_cpu_low_threshold            = var.push_cpu_low_threshold
+  ecs_as_mem_high_threshold           = var.push_mem_high_threshold
+  ecs_as_mem_low_threshold            = var.push_mem_low_threshold
+  tags                                = module.labels.tags
 }
 
 # #########################################

--- a/ecs_push.tf
+++ b/ecs_push.tf
@@ -24,6 +24,7 @@ data "aws_iam_policy_document" "push_ecs_task_policy" {
       aws_ssm_parameter.db_reader_host.arn,
       aws_ssm_parameter.db_ssl.arn,
       aws_ssm_parameter.default_country_code.arn,
+      aws_ssm_parameter.hsts_max_age.arn,
       aws_ssm_parameter.log_level.arn,
       aws_ssm_parameter.push_host.arn,
       aws_ssm_parameter.push_port.arn,

--- a/gateway.tf
+++ b/gateway.tf
@@ -207,8 +207,11 @@ resource "aws_api_gateway_method_response" "api_settings_get" {
     "application/json" = "Empty"
   }
   response_parameters = {
-    "method.response.header.Content-Length" = false,
-    "method.response.header.Content-Type"   = false
+    "method.response.header.Content-Length"            = false,
+    "method.response.header.Content-Type"              = false,
+    "method.response.header.Cache-Control"             = true,
+    "method.response.header.Pragma"                    = true,
+    "method.response.header.Strict-Transport-Security" = true
   }
 }
 
@@ -219,8 +222,11 @@ resource "aws_api_gateway_integration_response" "api_settings_get_integration" {
   selection_pattern = aws_api_gateway_method_response.api_settings_get.status_code
   status_code       = aws_api_gateway_method_response.api_settings_get.status_code
   response_parameters = {
-    "method.response.header.Content-Length" = "integration.response.header.Content-Length",
-    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+    "method.response.header.Content-Length"            = "integration.response.header.Content-Length",
+    "method.response.header.Content-Type"              = "integration.response.header.Content-Type",
+    "method.response.header.Cache-Control"             = "'no-store'",
+    "method.response.header.Pragma"                    = "'no-cache'",
+    "method.response.header.Strict-Transport-Security" = format("'max-age=%s; includeSubDomains'", var.hsts_max_age)
   }
 }
 
@@ -259,8 +265,11 @@ resource "aws_api_gateway_method_response" "api_settings_exposures_get" {
     "application/json" = "Empty"
   }
   response_parameters = {
-    "method.response.header.Content-Length" = false,
-    "method.response.header.Content-Type"   = false
+    "method.response.header.Content-Length"            = false,
+    "method.response.header.Content-Type"              = false,
+    "method.response.header.Cache-Control"             = true,
+    "method.response.header.Pragma"                    = true,
+    "method.response.header.Strict-Transport-Security" = true
   }
 }
 
@@ -271,8 +280,11 @@ resource "aws_api_gateway_integration_response" "api_settings_exposures_get_inte
   selection_pattern = aws_api_gateway_method_response.api_settings_exposures_get.status_code
   status_code       = aws_api_gateway_method_response.api_settings_exposures_get.status_code
   response_parameters = {
-    "method.response.header.Content-Length" = "integration.response.header.Content-Length",
-    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+    "method.response.header.Content-Length"            = "integration.response.header.Content-Length",
+    "method.response.header.Content-Type"              = "integration.response.header.Content-Type",
+    "method.response.header.Cache-Control"             = "'no-store'",
+    "method.response.header.Pragma"                    = "'no-cache'",
+    "method.response.header.Strict-Transport-Security" = format("'max-age=%s; includeSubDomains'", var.hsts_max_age)
   }
 }
 
@@ -310,8 +322,11 @@ resource "aws_api_gateway_method_response" "api_settings_language_get" {
     "application/json" = "Empty"
   }
   response_parameters = {
-    "method.response.header.Content-Length" = false,
-    "method.response.header.Content-Type"   = false
+    "method.response.header.Content-Length"            = false,
+    "method.response.header.Content-Type"              = false,
+    "method.response.header.Cache-Control"             = true,
+    "method.response.header.Pragma"                    = true,
+    "method.response.header.Strict-Transport-Security" = true
   }
 }
 
@@ -322,8 +337,11 @@ resource "aws_api_gateway_integration_response" "api_settings_language_get_integ
   selection_pattern = aws_api_gateway_method_response.api_settings_language_get.status_code
   status_code       = aws_api_gateway_method_response.api_settings_language_get.status_code
   response_parameters = {
-    "method.response.header.Content-Length" = "integration.response.header.Content-Length",
-    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+    "method.response.header.Content-Length"            = "integration.response.header.Content-Length",
+    "method.response.header.Content-Type"              = "integration.response.header.Content-Type",
+    "method.response.header.Cache-Control"             = "'no-store'",
+    "method.response.header.Pragma"                    = "'no-cache'",
+    "method.response.header.Strict-Transport-Security" = format("'max-age=%s; includeSubDomains'", var.hsts_max_age)
   }
 }
 
@@ -362,8 +380,11 @@ resource "aws_api_gateway_method_response" "api_stats_get" {
     "application/json" = "Empty"
   }
   response_parameters = {
-    "method.response.header.Content-Length" = false,
-    "method.response.header.Content-Type"   = false
+    "method.response.header.Content-Length"            = false,
+    "method.response.header.Content-Type"              = false,
+    "method.response.header.Cache-Control"             = true,
+    "method.response.header.Pragma"                    = true,
+    "method.response.header.Strict-Transport-Security" = true
   }
 }
 
@@ -374,8 +395,11 @@ resource "aws_api_gateway_integration_response" "api_stats_get_integration" {
   selection_pattern = aws_api_gateway_method_response.api_stats_get.status_code
   status_code       = aws_api_gateway_method_response.api_stats_get.status_code
   response_parameters = {
-    "method.response.header.Content-Length" = "integration.response.header.Content-Length",
-    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+    "method.response.header.Content-Length"            = "integration.response.header.Content-Length",
+    "method.response.header.Content-Type"              = "integration.response.header.Content-Type",
+    "method.response.header.Cache-Control"             = "'no-store'",
+    "method.response.header.Pragma"                    = "'no-cache'",
+    "method.response.header.Strict-Transport-Security" = format("'max-age=%s; includeSubDomains'", var.hsts_max_age)
   }
 }
 
@@ -435,8 +459,11 @@ resource "aws_api_gateway_method_response" "api_data_exposures_item_get_success"
     "application/zip"  = "Empty"
   }
   response_parameters = {
-    "method.response.header.Content-Length" = false,
-    "method.response.header.Content-Type"   = false
+    "method.response.header.Content-Length"            = false,
+    "method.response.header.Content-Type"              = false,
+    "method.response.header.Cache-Control"             = true,
+    "method.response.header.Pragma"                    = true,
+    "method.response.header.Strict-Transport-Security" = true
   }
 }
 
@@ -454,8 +481,11 @@ resource "aws_api_gateway_integration_response" "api_data_exposures_item_get_int
   status_code       = aws_api_gateway_method_response.api_data_exposures_item_get_success.status_code
   selection_pattern = aws_api_gateway_method_response.api_data_exposures_item_get_success.status_code
   response_parameters = {
-    "method.response.header.Content-Length" = "integration.response.header.Content-Length",
-    "method.response.header.Content-Type"   = "integration.response.header.Content-Type"
+    "method.response.header.Content-Length"            = "integration.response.header.Content-Length",
+    "method.response.header.Content-Type"              = "integration.response.header.Content-Type",
+    "method.response.header.Cache-Control"             = "'no-store'",
+    "method.response.header.Pragma"                    = "'no-cache'",
+    "method.response.header.Strict-Transport-Security" = format("'max-age=%s; includeSubDomains'", var.hsts_max_age)
   }
 }
 

--- a/gateway.tf
+++ b/gateway.tf
@@ -2,8 +2,9 @@
 # API Gateway REST API
 # #########################################
 resource "aws_api_gateway_rest_api" "main" {
-  name = "${module.labels.id}-gw"
-  tags = module.labels.tags
+  name                     = "${module.labels.id}-gw"
+  minimum_compression_size = var.api_gateway_minimum_compression_size
+  tags                     = module.labels.tags
 
   binary_media_types = [
     "application/zip",

--- a/lambda-exposures.tf
+++ b/lambda-exposures.tf
@@ -21,8 +21,10 @@ data "aws_iam_policy_document" "exposures_policy" {
       aws_ssm_parameter.db_port.arn,
       aws_ssm_parameter.db_ssl.arn,
       aws_ssm_parameter.default_region.arn,
+      aws_ssm_parameter.disable_valid_key_check.arn,
       aws_ssm_parameter.native_regions.arn,
-      aws_ssm_parameter.s3_assets_bucket.arn
+      aws_ssm_parameter.s3_assets_bucket.arn,
+      aws_ssm_parameter.variance_offset_mins.arn
     ]
   }
 

--- a/modules/ecs-autoscale-service/main.tf
+++ b/modules/ecs-autoscale-service/main.tf
@@ -21,6 +21,14 @@ variable "ecs_autoscale_min_instances" {
   default = 1
 }
 
+variable "ecs_autoscale_scale_down_adjustment" {
+  default = -1
+}
+
+variable "ecs_autoscale_scale_up_adjustment" {
+  default = 1
+}
+
 variable "ecs_as_cpu_high_threshold" {
   default = 60
 }
@@ -70,7 +78,7 @@ resource "aws_appautoscaling_policy" "scale_up" {
 
     step_adjustment {
       metric_interval_lower_bound = 0
-      scaling_adjustment          = 1
+      scaling_adjustment          = var.ecs_autoscale_scale_up_adjustment
     }
   }
 }
@@ -89,7 +97,7 @@ resource "aws_appautoscaling_policy" "scale_down" {
 
     step_adjustment {
       metric_interval_upper_bound = 0
-      scaling_adjustment          = -1
+      scaling_adjustment          = var.ecs_autoscale_scale_down_adjustment
     }
   }
 }

--- a/parameters.tf
+++ b/parameters.tf
@@ -145,6 +145,14 @@ resource "aws_ssm_parameter" "certificate_audience" {
   tags      = module.labels.tags
 }
 
+resource "aws_ssm_parameter" "hsts_max_age" {
+  overwrite = true
+  name      = "${local.config_var_prefix}hsts_max_age"
+  type      = "String"
+  value     = var.hsts_max_age
+  tags      = module.labels.tags
+}
+
 resource "aws_ssm_parameter" "jwt_issuer" {
   overwrite = true
   name      = "${local.config_var_prefix}jwt_issuer"

--- a/parameters.tf
+++ b/parameters.tf
@@ -185,6 +185,14 @@ resource "aws_ssm_parameter" "native_regions" {
   tags      = module.labels.tags
 }
 
+resource "aws_ssm_parameter" "onset_date_mandatory" {
+  overwrite = true
+  name      = "${local.config_var_prefix}onset_date_mandatory"
+  type      = "String"
+  value     = var.onset_date_mandatory
+  tags      = module.labels.tags
+}
+
 resource "aws_ssm_parameter" "push_host" {
   overwrite = true
   name      = "${local.config_var_prefix}push_host"

--- a/parameters.tf
+++ b/parameters.tf
@@ -105,6 +105,14 @@ resource "aws_ssm_parameter" "default_region" {
   tags      = module.labels.tags
 }
 
+resource "aws_ssm_parameter" "disable_valid_key_check" {
+  overwrite = true
+  name      = "${local.config_var_prefix}disable_valid_key_check"
+  type      = "String"
+  value     = var.disable_valid_key_check
+  tags      = module.labels.tags
+}
+
 resource "aws_ssm_parameter" "enable_callback" {
   overwrite = true
   name      = "${local.config_var_prefix}enable_callback"
@@ -342,6 +350,14 @@ resource "aws_ssm_parameter" "use_test_date_as_onset_date" {
   name      = "${local.config_var_prefix}use_test_date_as_onset_date"
   type      = "String"
   value     = var.use_test_date_as_onset_date
+  tags      = module.labels.tags
+}
+
+resource "aws_ssm_parameter" "variance_offset_mins" {
+  overwrite = true
+  name      = "${local.config_var_prefix}variance_offset_mins"
+  type      = "String"
+  value     = var.variance_offset_mins
   tags      = module.labels.tags
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -371,6 +371,10 @@ variable "health_check_unhealthy_threshold" {
   description = "Health check unhealthy threshold for ALB health checks"
   default     = 2
 }
+variable "hsts_max_age" {
+  description = "The time, in seconds, that the browser should remember that a site is only to be accessed using HTTPS."
+  default     = "300" // 5 minutes
+}
 variable "lambda_authorizer_memory_size" {
   description = "authorizer lambda memory size"
   default     = 512 # Since this is on the hot path and we get faster CPUs with higher memory

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,10 @@ variable "api_gateway_account_creation_enabled" {
   description = "APIGateway account creation flag, this is used for CloudWatch logging, should only have one of these per account/region, this flag allows disabling if one already exists"
   default     = true
 }
+variable "api_gateway_minimum_compression_size" {
+  description = "APIGateway minimum response size to compress for the REST API. Integer between -1 and 10485760 (10MB). Setting a value greater than -1 will enable compression, -1 disables compression (default)"
+  default     = -1
+}
 variable "api_gateway_throttling_burst_limit" {
   description = "APIGateway throttling burst limit, default is -1 which does not enforce a limit"
   default     = -1
@@ -223,6 +227,14 @@ variable "api_ecs_autoscale_max_instances" {
 }
 variable "api_ecs_autoscale_min_instances" {
   description = "ECS API service ASG min count"
+  default     = 1
+}
+variable "api_ecs_autoscale_scale_down_adjustment" {
+  description = "ECS API service ASG scaling scale down adjustment"
+  default     = -1
+}
+variable "api_ecs_autoscale_scale_up_adjustment" {
+  description = "ECS API service ASG scaling scale up adjustment"
   default     = 1
 }
 variable "api_image_tag" {
@@ -571,6 +583,14 @@ variable "push_ecs_autoscale_max_instances" {
 }
 variable "push_ecs_autoscale_min_instances" {
   description = "ECS Push service ASG min count"
+  default     = 1
+}
+variable "push_ecs_autoscale_scale_down_adjustment" {
+  description = "ECS Push service ASG scaling scale down adjustment"
+  default     = -1
+}
+variable "push_ecs_autoscale_scale_up_adjustment" {
+  description = "ECS Push service ASG scaling scale up adjustment"
   default     = 1
 }
 variable "push_image_tag" {

--- a/variables.tf
+++ b/variables.tf
@@ -195,6 +195,10 @@ variable "sms_monthly_spend_limit" {
 # #########################################
 # WAF
 # #########################################
+variable "attach_waf" {
+  type    = bool
+  default = true
+}
 # List of allowed country alpha 2 codes, see https://www.iso.org/obp/ui/#search
 # If this is empty then we do not restrict based on country
 variable "waf_geo_allowed_countries" {

--- a/variables.tf
+++ b/variables.tf
@@ -553,6 +553,10 @@ variable "migrations_image_tag" {
   description = "Image tag for the ECS Migrations container"
   default     = "latest"
 }
+variable "onset_date_mandatory" {
+  description = "Flag whether onsetDate/symptomDate is mandatory"
+  default     = "false"
+}
 variable "optional_lambdas_to_include" {
   description = "List of optional lambdas to include"
   default     = []

--- a/variables.tf
+++ b/variables.tf
@@ -320,6 +320,10 @@ variable "default_region" {
   description = "Default region to use for exposure key uploads where the region is not provided"
   default     = ""
 }
+variable "disable_valid_key_check" {
+  description = "Flag to disable whether exposure keys which are still valid are ignored when generating export files"
+  default     = "false"
+}
 variable "download_schedule" {
   description = "download lambda CloudWatch schedule"
   default     = "cron(0 * * * ? *)"
@@ -682,6 +686,10 @@ variable "upload_token_lifetime_mins" {
 variable "use_test_date_as_onset_date" {
   description = "Flag to use the testDate as the onsetDate if the latter is omitted"
   default     = "false"
+}
+variable "variance_offset_mins" {
+  description = "Variance offset in minutes to add to lifetime of keys to check if they are still valid"
+  default     = "120"
 }
 variable "verify_rate_limit_secs" {
   description = "Time in seconds a user must wait before attempting to verify a one-time upload code"

--- a/waf.tf
+++ b/waf.tf
@@ -256,16 +256,19 @@ resource "aws_wafregional_rule" "xss" {
 }
 
 resource "aws_wafregional_web_acl_association" "gateway" {
+  count        = var.attach_waf ? 1 : 0
   resource_arn = aws_api_gateway_stage.live.arn
   web_acl_id   = aws_wafregional_web_acl.acl.id
 }
 
 resource "aws_wafregional_web_acl_association" "api" {
+  count        = var.attach_waf ? 1 : 0
   resource_arn = aws_lb.api.arn
   web_acl_id   = aws_wafregional_web_acl.acl.id
 }
 
 resource "aws_wafregional_web_acl_association" "push" {
+  count        = var.attach_waf ? 1 : 0
   resource_arn = aws_lb.push.arn
   web_acl_id   = aws_wafregional_web_acl.acl.id
 }


### PR DESCRIPTION
- Added: Added "attach_waf" variable to attach/detach WAF to ALB and API Gateway
- Added: Added "disable_valid_key_check" variable to flag whether to disable check if key is still valid when generating export files
- Added: Added "variance_offset_mins" variable to add to lifetime of keys to check if they are still valid
- Added: Added "onset_date_mandatory" variable to control whether onsetDate/symptomDate is mandatory
- Added: New "api_gateway_minimum_compression_size" to allow compression configuration on the APIGateway
- Added: New variables to control ECS scaling adjustments
- api_ecs_autoscale_scale_down_adjustment
- api_ecs_autoscale_scale_up_adjustment
- push_ecs_autoscale_scale_down_adjustment
- push_ecs_autoscale_scale_up_adjustment
- Added: SUPPORT_REQUESTS.md
- Added: Headers Cache-Control, Pragma, Strict-Transport-Security
- Changed: Push API TLS 1.2 enforcement