### PR TITLE
v0.1.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 All notable changes to this project will be documented in this file.
 
 ##  Unreleased
-- Added: clouwatch container insights activation option
+- Deleted: ci-user security access key credentials, so they are not included in the statefile and output
+- Added: CloudWatch container insights activation option - default is disabled
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
 
 ## [v0.1.9] 2020-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
-## ## [v0.1.10] Unreleased
-- Added: Added "api_gateway_timeout_milliseconds" variable to control the API Gateway
+## [v0.1.10] Unreleased
+- Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
 
 ## [v0.1.9] 2020-09-29
 - Removed: Cloudwatch dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.1.10] Unreleased
+##  Unreleased
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
 
 ## [v0.1.9] 2020-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ##  Unreleased
+- Added: clouwatch container insights activation option
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
 
 ## [v0.1.9] 2020-09-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ##  Unreleased
+- Added: "cso_schedule" variable to control the cso lambda schedule
 - Deleted: ci-user security access key credentials, so they are not included in the statefile and output
 - Added: CloudWatch container insights activation option - default is disabled
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
-##  Unreleased
+## Unreleased
+
+
+## [v0.1.10] 2020-10-07
+- Updated: "lambda_callback_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
+- Updated: "lambda_exposures_timeout" variable default to 180s as we have observed current 60s is insufficent for many tenants
+- Updated: "lambda_sms_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
 - Added: "cso_schedule" variable to control the cso lambda schedule
 - Deleted: ci-user security access key credentials, so they are not included in the statefile and output
 - Added: CloudWatch container insights activation option - default is disabled
 - Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway
+
 
 ## [v0.1.9] 2020-09-29
 - Removed: Cloudwatch dashboard

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 All notable changes to this project will be documented in this file.
 
+## ## [v0.1.10] Unreleased
+- Added: Added "api_gateway_timeout_milliseconds" variable to control the API Gateway
 
 ## [v0.1.9] 2020-09-29
 - Removed: Cloudwatch dashboard

--- a/docs/creating-a-new-project.md
+++ b/docs/creating-a-new-project.md
@@ -136,6 +136,8 @@ Will need to create the following targets.
 
 
 ## Post standup tasks
+- Create the ci-user's access key if needed for CI/CD
+	- `aws iam create-access-key --user-name dev-xyz`
 - Enable PostgreSQL extensions and create DB users - see [here](./db.md)
 - Seed the DB setting(s) tables
 - Complete DNS config if needed - with external party

--- a/ecs.tf
+++ b/ecs.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "services" {
   tags = module.labels.tags
 
   setting {
-    name = "containerInsights"
+    name  = "containerInsights"
     value = var.enable_ecs_container_insights ? "enabled" : "disabled"
   }
 }

--- a/ecs.tf
+++ b/ecs.tf
@@ -3,4 +3,10 @@
 # #########################################
 resource "aws_ecs_cluster" "services" {
   name = module.labels.id
+  tags = module.labels.tags
+
+  setting {
+    name = "containerInsights"
+    value = var.enable_ecs_container_insights ? "enabled" : "disabled"
+  }
 }

--- a/gateway.tf
+++ b/gateway.tf
@@ -79,11 +79,11 @@ resource "aws_api_gateway_method" "root" {
 }
 
 resource "aws_api_gateway_integration" "root" {
-  rest_api_id = aws_api_gateway_rest_api.main.id
-  resource_id = aws_api_gateway_rest_api.main.root_resource_id
-  http_method = aws_api_gateway_method.root.http_method
+  rest_api_id          = aws_api_gateway_rest_api.main.id
+  resource_id          = aws_api_gateway_rest_api.main.root_resource_id
+  http_method          = aws_api_gateway_method.root.http_method
   timeout_milliseconds = var.api_gateway_timeout_milliseconds
-  type        = "MOCK"
+  type                 = "MOCK"
   request_templates = {
     "application/json" = jsonencode({ statusCode : 404 })
   }

--- a/gateway.tf
+++ b/gateway.tf
@@ -82,6 +82,7 @@ resource "aws_api_gateway_integration" "root" {
   rest_api_id = aws_api_gateway_rest_api.main.id
   resource_id = aws_api_gateway_rest_api.main.root_resource_id
   http_method = aws_api_gateway_method.root.http_method
+  timeout_milliseconds = var.api_gateway_timeout_milliseconds
   type        = "MOCK"
   request_templates = {
     "application/json" = jsonencode({ statusCode : 404 })
@@ -149,6 +150,7 @@ resource "aws_api_gateway_integration" "api_proxy_any_integration" {
   rest_api_id             = aws_api_gateway_rest_api.main.id
   resource_id             = aws_api_gateway_resource.api_proxy.id
   http_method             = aws_api_gateway_method.api_proxy_any.http_method
+  timeout_milliseconds    = var.api_gateway_timeout_milliseconds
   integration_http_method = "ANY"
   type                    = "HTTP_PROXY"
   uri                     = "http://${aws_lb.api.dns_name}/{proxy}"
@@ -192,6 +194,7 @@ resource "aws_api_gateway_integration" "api_settings_get_integration" {
   rest_api_id             = aws_api_gateway_rest_api.main.id
   resource_id             = aws_api_gateway_resource.api_settings.id
   http_method             = aws_api_gateway_method.api_settings_get.http_method
+  timeout_milliseconds    = var.api_gateway_timeout_milliseconds
   integration_http_method = "GET"
   type                    = "AWS"
   uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/${aws_s3_bucket.assets.id}/settings.json"
@@ -250,6 +253,7 @@ resource "aws_api_gateway_integration" "api_settings_exposures_get_integration" 
   rest_api_id             = aws_api_gateway_rest_api.main.id
   resource_id             = aws_api_gateway_resource.api_settings_exposures.id
   http_method             = aws_api_gateway_method.api_settings_exposures_get.http_method
+  timeout_milliseconds    = var.api_gateway_timeout_milliseconds
   integration_http_method = "GET"
   type                    = "AWS"
   uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/${aws_s3_bucket.assets.id}/exposures.json"
@@ -307,6 +311,7 @@ resource "aws_api_gateway_integration" "api_settings_language_get_integration" {
   rest_api_id             = aws_api_gateway_rest_api.main.id
   resource_id             = aws_api_gateway_resource.api_settings_language.id
   http_method             = aws_api_gateway_method.api_settings_language_get.http_method
+  timeout_milliseconds    = var.api_gateway_timeout_milliseconds
   integration_http_method = "GET"
   type                    = "AWS"
   uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/${aws_s3_bucket.assets.id}/language.json"
@@ -365,6 +370,7 @@ resource "aws_api_gateway_integration" "api_stats_get_integration" {
   rest_api_id             = aws_api_gateway_rest_api.main.id
   resource_id             = aws_api_gateway_resource.api_stats.id
   http_method             = aws_api_gateway_method.api_stats_get.http_method
+  timeout_milliseconds    = var.api_gateway_timeout_milliseconds
   integration_http_method = "GET"
   type                    = "AWS"
   uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/${aws_s3_bucket.assets.id}/stats.json"
@@ -440,6 +446,7 @@ resource "aws_api_gateway_integration" "api_data_exposures_item_get_integration"
   rest_api_id             = aws_api_gateway_rest_api.main.id
   resource_id             = aws_api_gateway_resource.api_data_exposures_item.id
   http_method             = aws_api_gateway_method.api_data_exposures_item_get.http_method
+  timeout_milliseconds    = var.api_gateway_timeout_milliseconds
   integration_http_method = "GET"
   type                    = "AWS"
   uri                     = "arn:aws:apigateway:${var.aws_region}:s3:path/${aws_s3_bucket.assets.id}/exposures/{item}"

--- a/lambda-cso.tf
+++ b/lambda-cso.tf
@@ -118,7 +118,7 @@ resource "aws_lambda_function" "cso" {
 
 resource "aws_cloudwatch_event_rule" "cso_schedule" {
   count               = local.lambda_cso_count
-  schedule_expression = "cron(0 0 * * ? *)"
+  schedule_expression = var.cso_schedule
 }
 
 resource "aws_cloudwatch_event_target" "cso_schedule" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -31,10 +31,6 @@ output "intra_subnets" {
   value = module.vpc.intra_subnets
 }
 
-output "key" {
-  value = aws_iam_access_key.ci_user.id
-}
-
 output "lambda_authorizer_name" {
   value = aws_lambda_function.authorizer.function_name
 }
@@ -109,10 +105,6 @@ output "rds_endpoint" {
 
 output "rds_reader_endpoint" {
   value = module.rds_cluster_aurora_postgres.reader_endpoint
-}
-
-output "secret" {
-  value = aws_iam_access_key.ci_user.secret
 }
 
 output "vpc_id" {

--- a/users.tf
+++ b/users.tf
@@ -3,10 +3,6 @@ resource "aws_iam_user" "ci_user" {
   tags = module.labels.tags
 }
 
-resource "aws_iam_access_key" "ci_user" {
-  user = aws_iam_user.ci_user.name
-}
-
 resource "aws_iam_user_policy_attachment" "ci_user_ecr" {
   user       = aws_iam_user.ci_user.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess"

--- a/variables.tf
+++ b/variables.tf
@@ -105,7 +105,7 @@ variable "push_eu_certificate_arn" {
 # ECS Cluster Settings
 # #########################################
 variable "enable_ecs_container_insights" {
-  description = "Enable or disable Cloudwatch Container insights for the ECS cluster"
+  description = "Enable or disable CloudWatch Container insights for the ECS cluster"
   default     = false
 }
 
@@ -116,6 +116,7 @@ variable "default_ecr_max_image_count" {
   description = "Default ECR image retention count used for purging the ECR repositories"
   default     = 30
 }
+
 # #########################################
 # Load Balancer
 # #########################################

--- a/variables.tf
+++ b/variables.tf
@@ -329,6 +329,10 @@ variable "code_removal_mins" {
   description = "Lifetime in minutes before a one-time upload code is removed from the database"
   default     = "10080"
 }
+variable "cso_schedule" {
+  description = "cso lambda CloudWatch schedule"
+  default     = "cron(0 0 * * ? *)"
+}
 variable "daily_registrations_reporter_email_subject" {
   description = "daily-registrations-reporter lambda email subject text"
   default     = ""

--- a/variables.tf
+++ b/variables.tf
@@ -434,7 +434,7 @@ variable "lambda_callback_s3_key" {
 }
 variable "lambda_callback_timeout" {
   description = "callback lambda timeout"
-  default     = 15
+  default     = 180
 }
 variable "lambda_custom_runtimes" {
   description = "Map of lambdas to use custom runtimes, where the value is an object with the runtime and layers to use i.e. { \"authorizer\" : { \"runtime\": \"provided\", \"layers\": [\"some-arn\"] } }"
@@ -502,7 +502,7 @@ variable "lambda_exposures_s3_key" {
 }
 variable "lambda_exposures_timeout" {
   description = "exposures lambda timeout"
-  default     = 60
+  default     = 180
 }
 variable "lambda_provisioned_concurrencies" {
   description = "Map of lambdas to use provisioned concurrency i.e. { \"authorizer\" : 300 }"
@@ -530,7 +530,7 @@ variable "lambda_sms_s3_key" {
 }
 variable "lambda_sms_timeout" {
   description = "sms lambda timeout"
-  default     = 15
+  default     = 180
 }
 variable "lambda_stats_memory_size" {
   description = "stats lambda memory size"

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,10 @@ variable "api_gateway_throttling_rate_limit" {
   description = "APIGateway throttling rate limit, default is -1 which does not enforce a limit"
   default     = -1
 }
-
+variable "api_gateway_timeout_milliseconds" {
+  description = "APIGateway integration request timeout (in milliseconds)"
+  default     = 6000
+}
 # #########################################
 # Bastion
 # #########################################

--- a/variables.tf
+++ b/variables.tf
@@ -51,7 +51,7 @@ variable "api_gateway_throttling_rate_limit" {
 }
 variable "api_gateway_timeout_milliseconds" {
   description = "APIGateway integration request timeout (in milliseconds)"
-  default     = 6000
+  default     = 29000
 }
 # #########################################
 # Bastion

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,14 @@ variable "push_eu_certificate_arn" {
 }
 
 # #########################################
+# ECS Cluster Settings
+# #########################################
+variable "enable_ecs_container_insights" {
+  description = "Enable or disable Cloudwatch Container insights for the ECS cluster"
+  default     = false
+}
+
+# #########################################
 # ECR Settings
 # #########################################
 variable "default_ecr_max_image_count" {


### PR DESCRIPTION
- Updated: "lambda_callback_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
- Updated: "lambda_exposures_timeout" variable default to 180s as we have observed current 60s is insufficent for many tenants
- Updated: "lambda_sms_timeout" variable default to 180s as we have observed current 15s is insufficent for many tenants
- Added: "cso_schedule" variable to control the cso lambda schedule
- Deleted: ci-user security access key credentials, so they are not included in the statefile and output
- Added: CloudWatch container insights activation option - default is disabled
- Added: "api_gateway_timeout_milliseconds" variable to control the API Gateway